### PR TITLE
Make android package scripts smarter

### DIFF
--- a/PackageApp.bat
+++ b/PackageApp.bat
@@ -1,4 +1,6 @@
 @echo off
+:: Keep environment variables from leaving the script
+setlocal
 set PAUSE_ERRORS=1
 call bat\SetupSDK.bat
 call bat\SetupApplication.bat
@@ -7,46 +9,62 @@ call bat\SetupApplication.bat
 echo.
 echo Package for target
 echo.
-echo Android:
+echo Android for ARMv7:
 echo.
 echo  [1] normal       (apk)
 echo  [2] debug        (apk-debug)
 echo  [3] captive      (apk-captive-runtime)
 echo.
+echo Android for x86:
+echo.
+echo  [4] normal       (apk)
+echo  [5] debug        (apk-debug)
+echo  [6] captive      (apk-captive-runtime)
+echo.
 echo iOS:
 echo.
-echo  [4] fast test    (ipa-test-interpreter)
-echo  [5] fast debug   (ipa-debug-interpreter)
-echo  [6] slow test    (ipa-test)
-echo  [7] slow debug   (ipa-debug)
-echo  [8] "ad-hoc"     (ipa-ad-hoc)
-echo  [9] App Store    (ipa-app-store)
+echo  [7] fast test    (ipa-test-interpreter)
+echo  [8] fast debug   (ipa-debug-interpreter)
+echo  [9] slow test    (ipa-test)
+echo  [10] slow debug   (ipa-debug)
+echo  [11] "ad-hoc"     (ipa-ad-hoc)
+echo  [12] App Store    (ipa-app-store)
 echo.
+echo.
+echo The captive runtimes for Android run 4-5 times faster than normal apk, but are larger and require Adobe AIR and more RAM.
 
 :choice
 set /P C=[Choice]: 
 echo.
 
 set PLATFORM=android
+set ARCH=armv7
 set OPTIONS=
-if %C% GTR 3 set PLATFORM=ios
-if %C% GTR 7 set PLATFORM=ios-dist
+if %C% GTR 3 set ARCH=x86
+if %C% GTR 6 set PLATFORM=ios
+if %C% GTR 10 set PLATFORM=ios-dist
 
 if "%C%"=="1" set TARGET=
 if "%C%"=="2" set TARGET=-debug -captive-runtime
 if "%C%"=="2" set OPTIONS=-connect %DEBUG_IP%
 if "%C%"=="3" set TARGET=-captive-runtime
 
-if "%C%"=="4" set TARGET=-test-interpreter
-if "%C%"=="5" set TARGET=-debug-interpreter
+if "%C%"=="4" set TARGET=
+if "%C%"=="5" set TARGET=-debug -captive-runtime
 if "%C%"=="5" set OPTIONS=-connect %DEBUG_IP%
-if "%C%"=="6" set TARGET=-test
-if "%C%"=="7" set TARGET=-debug
-if "%C%"=="7" set OPTIONS=-connect %DEBUG_IP%
-if "%C%"=="8" set TARGET=-ad-hoc
-if "%C%"=="9" set TARGET=-app-store
+if "%C%"=="6" set TARGET=-captive-runtime
+
+if "%C%"=="7" set TARGET=-test-interpreter
+if "%C%"=="8" set TARGET=-debug-interpreter
+if "%C%"=="8" set OPTIONS=-connect %DEBUG_IP%
+if "%C%"=="9" set TARGET=-test
+if "%C%"=="10" set TARGET=-debug
+if "%C%"=="10" set OPTIONS=-connect %DEBUG_IP%
+if "%C%"=="11" set TARGET=-ad-hoc
+if "%C%"=="12" set TARGET=-app-store
 
 call bat\Packager.bat
+if %ERRORLEVEL% == 1 exit /b
 
 if "%PLATFORM%"=="android" goto android-package
 

--- a/application.xml
+++ b/application.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?> 
-<application xmlns="http://ns.adobe.com/air/application/15.0">
+<application xmlns="http://ns.adobe.com/air/application/16.0">
 	
-	<id>air.AirTemplateProj</id>
+	<id>com.fenoxo.tits</id>
 	<versionNumber>0.1</versionNumber>
 	<supportedProfiles>mobileDevice</supportedProfiles>
-	<filename>AirTemplateProj</filename>
+	<filename>TiTS</filename>
 	
-	<name>AirTemplateProj</name>
+	<name>TiTS</name>
 	<description></description>
 	<copyright></copyright>
 	
@@ -48,7 +48,7 @@
 	
 	<initialWindow>
 		<title>TiTS AIR DEV</title>
-		<content>AirTemplateProj.swf</content>
+		<content>TITS_AIR.swf</content>
 		<visible>true</visible>
 		<fullScreen>true</fullScreen>
 		<!--<autoOrients>false</autoOrients>-->

--- a/bat/Packager.bat
+++ b/bat/Packager.bat
@@ -41,7 +41,8 @@ set OUTPUT=%DIST_PATH%\%DIST_NAME%%TARGET%.%DIST_EXT%
 echo Packaging: %OUTPUT%
 echo using certificate: %CERT_FILE%...
 echo.
-call adt -package -target %TYPE%%TARGET% %OPTIONS% %SIGNING_OPTIONS% "%OUTPUT%" "%APP_XML%" %FILE_OR_DIR%
+:: echo adt -package -target %TYPE%%TARGET% -arch %ARCH% %OPTIONS% %SIGNING_OPTIONS% "%OUTPUT%" "%APP_XML%" %FILE_OR_DIR%
+call adt -package -target %TYPE%%TARGET% -arch %ARCH% %OPTIONS% %SIGNING_OPTIONS% "%OUTPUT%" "%APP_XML%" %FILE_OR_DIR%
 echo.
 if errorlevel 1 goto failed
 goto end
@@ -58,7 +59,7 @@ echo - configure your developer key and project's Provisioning Profile
 echo   in 'bat\SetupApplication.bat'.
 echo.
 if %PAUSE_ERRORS%==1 pause
-exit
+exit /b 1
 
 :failed
 echo APK setup creation FAILED.
@@ -68,6 +69,7 @@ echo - did you build your project in FlashDevelop?
 echo - verify AIR SDK target version in %APP_XML%
 echo.
 if %PAUSE_ERRORS%==1 pause
-exit
+exit /b 1
 
 :end
+exit /b 0

--- a/bat/SetupSDK.bat
+++ b/bat/SetupSDK.bat
@@ -1,10 +1,16 @@
 :user_configuration
 
 :: Path to Flex SDK
-set FLEX_SDK=C:\Users\Gedan\AppData\Local\FlashDevelop\Apps\flexairsdk\4.6.0+16.0.0
+if defined FLEX_SDK goto manual_flexsdk
+:: Windows uses version-sort by default, instead of simple string comparison.
+:: The result is that the highest version of the SDK installed will be last.
+for /d %%D in ( "%LOCALAPPDATA%\FlashDevelop\Apps\flexairsdk\*" ) DO set FLEX_SDK=%%D
+
+:manual_flexsdk
 set AUTO_INSTALL_IOS=yes
 
 :: Path to Android SDK
+if defined ANDROID_SDK goto validation
 set ANDROID_SDK=C:\Program Files (x86)\FlashDevelop\Tools\android
 
 


### PR DESCRIPTION
The script now respects pre-set FLEX_SDK and ANDROID_SDK environment variables.

It also has extra options to build for Android systems with x86 processors (added in SDK since AIR 14)