### PR TITLE
Minor Fixes and Updates

### DIFF
--- a/classes/Creature.as
+++ b/classes/Creature.as
@@ -6793,7 +6793,7 @@ package classes {
 			if(fullnessDelta + milkFullness > 100)
 			{
 				//Vanae milk just caps at 100.
-				if(milkType == GLOBAL.FLUID_TYPE_VANAE_HUNTRESS_MILK) milkFullness = 100;
+				if(InCollection(milkType, GLOBAL.FLUID_TYPE_VANAE_MAIDEN_MILK, GLOBAL.FLUID_TYPE_VANAE_HUNTRESS_MILK)) milkFullness = 100;
 				else
 				{
 					//If we start below 100, do that normally first

--- a/classes/GameData/CombatAttacks.as
+++ b/classes/GameData/CombatAttacks.as
@@ -814,7 +814,7 @@ package classes.GameData
 				}
 				else
 				{
-					output(attacker.mfn("He","She","It") + " he misses.");
+					output(attacker.mfn("He","She","It") + " misses.");
 				}
 			}
 			//Extra miss for blind

--- a/classes/GameData/CombatContainer.as
+++ b/classes/GameData/CombatContainer.as
@@ -1552,8 +1552,8 @@ package classes.GameData
 		
 			addButton(3, "Hips", teaseHips, target, "Hips Tease", "Use your [pc.hips] to tease your enemy.");
 			
-			if (pc.milkType == GLOBAL.FLUID_TYPE_VANAE_HUNTRESS_MILK && pc.isLactating()) addButton(4, "Milk Squirt", teaseSquirt, target, "Milk Squirt", "Spray the enemy with your vanae milk, arousing them.");
-			else if (pc.milkType == GLOBAL.FLUID_TYPE_VANAE_HUNTRESS_MILK) addDisabledButton(4, "Milk Squirt", "Milk Squirt", "You do not currently have enough milk available to squirt any.");
+			if ((InCollection(pc.milkType, GLOBAL.FLUID_TYPE_VANAE_MAIDEN_MILK, GLOBAL.FLUID_TYPE_VANAE_HUNTRESS_MILK) && pc.isLactating()) || (pc.isMilkTank() && pc.canMilkSquirt())) addButton(4, "Milk Squirt", teaseSquirt, target, "Milk Squirt", "Spray the enemy with your [pc.milk], arousing them.");
+			else if (InCollection(pc.milkType, GLOBAL.FLUID_TYPE_VANAE_MAIDEN_MILK, GLOBAL.FLUID_TYPE_VANAE_HUNTRESS_MILK) || pc.isMilkTank()) addDisabledButton(4, "Milk Squirt", "Milk Squirt", "You do not currently have enough [pc.milkNoun] available to squirt any.");
 			addButton(14, "Back", generateCombatMenu, undefined, "Back", "Back out. Recommended if you haven't yet used \"Sense\" to determine your foe's likes and dislikes. Remember you can pull up your appearance screen in combat or use the scene buffer buttons in the lower left corner to compare yourself to your foe's preferences!");
 		}
 		
@@ -2459,7 +2459,7 @@ package classes.GameData
 				damage = Math.ceil(damage);
 			
 				output("\n\n");
-				if(teaseType == "squirt") 
+				if(teaseType == "SQUIRT") 
 				{
 					if(target.isPlural) output(target.capitalA + target.uniqueName  + " are splattered with your [pc.milk], unable to get it off. All of a sudden, their faces begin to flush, and they look quite aroused.");
 					else output(target.capitalA + target.uniqueName  + " is splattered with your [pc.milk], unable to get it off. All of a sudden, " + target.mfn("his","her","its") + " " + target.face() + " begins to flush, and " + target.mfn("he","she","it") + " looks quite aroused.");
@@ -2483,7 +2483,7 @@ package classes.GameData
 				teaseSkillUp(teaseType);
 				if(target is MyrInfectedFemale && damage >= 10)
 				{
-					output("<b>Your teasing has the poor girl in a shuddering mess as she tries to regain control of her lust addled nerves.</b>");
+					//output("\n\n<b>Your teasing has the poor girl in a shuddering mess as she tries to regain control of her lust addled nerves.</b>");
 					var stunDur:int = 1 + rand(2);
 					target.createStatusEffect("Stunned",stunDur,0,0,0,false,"Stun","Cannot take action!",true,0);
 					target.createStatusEffect("Lust Stunned",stunDur,0,0,0,true,"Stun","Cannot take action!",true,0);

--- a/classes/Items/Miscellaneous/SkySap.as
+++ b/classes/Items/Miscellaneous/SkySap.as
@@ -8,6 +8,7 @@
 	import classes.GameData.TooltipManager;
 	import classes.StringUtil;
 	import classes.Engine.Interfaces.author;
+	import classes.Util.InCollection;
 	import classes.Util.RandomInCollection;
 	
 	public class SkySap extends ItemSlotClass
@@ -373,11 +374,12 @@
 				// PC must have A cup or larger breasts
 				// PC must not already have Vanae milk
 				// The PC begins to lactate (if not already doing so) and lactation type becomes Vanae_Maiden, Vanae_Huntress, or Vanae_Matron.
-				if(pc.biggestTitSize() >= 1 && pc.milkType != GLOBAL.FLUID_TYPE_VANAE_HUNTRESS_MILK && pc.vanaeScore() > 2 && changes < changeLimit && rand(4) == 0)
+				if(pc.biggestTitSize() >= 1 && !InCollection(pc.milkType, GLOBAL.FLUID_TYPE_VANAE_MAIDEN_MILK, GLOBAL.FLUID_TYPE_VANAE_HUNTRESS_MILK) && pc.vanaeScore() > 2 && changes < changeLimit && rand(4) == 0)
 				{
 					outputB("\n\nYou grab your [pc.breasts] and feel a churning, filling sensation inside of them. Your [pc.nipplesNoun] poke out through your fingertips, lewdly erect, and [pc.milk] begins to orgasmically spurt from your udders. You moan and milk your wildly spurting peaks, literally creaming yourself long and hard.");
 					// Milk change here to Vanae_maiden, Vanae_Huntress, or Vanae_Matron milk.
-					pc.milkType = GLOBAL.FLUID_TYPE_VANAE_HUNTRESS_MILK;
+					if(pc.hasVirginVagina()) pc.milkType = GLOBAL.FLUID_TYPE_VANAE_MAIDEN_MILK;
+					else pc.milkType = GLOBAL.FLUID_TYPE_VANAE_HUNTRESS_MILK;
 					if(pc.milkMultiplier < 80) pc.milkMultiplier = 80;
 					if(pc.milkFullness < 50) pc.milkFullness = 50;
 					outputB("\n\nDrowning in pleasure, you utterly cum out the contents of your [pc.breasts] until they're emptied, and something new fills it instead. Fruity, [pc.milkColor] fluid flows out from between your fingers. Bringing your digits up, you lick some off. Just a little taste is enough to make you flush with arousal. Your breast milk is now filled with aphrodisiacs. <b>You now have [pc.milkColor] vanae breast milk!</b>");

--- a/includes/CodexEntries.as
+++ b/includes/CodexEntries.as
@@ -718,30 +718,25 @@ public function VKoIVsCodex():void
 	clearOutputCodex();
 	showBust("VI");
 	outputCodex(header("V-Ko IV Nursedroids"));
-	outputCodex("The V-Ko IV is a more expensive, advanced variant of the original V-Ko model, coded with a more organic and lively bedside manner. Another noticeable difference is the inclusion of a prehensile tail, which can be used for treatment, or as a dock for many medical apparatus.\n\n");
-	outputCodex("Several model variants were released, each designed to fit into different social settings, including versions designed to integrate into unclothed societies.\n\n");
+	outputCodex("The V-Ko IV is a more expensive, advanced variant of the original V-Ko model, coded with a more organic and lively bedside manner. Another noticeable difference is the inclusion of a prehensile tail, which can be used for treatment, or as a dock for many medical apparatus.\n\nSeveral model variants were released, each designed to fit into different social settings, including versions designed to integrate into unclothed societies.\n\n");
 	outputCodex("<b>Sexes:</b> V-Ko IVs are all female in appearance, and unlike the original line of V-Ko units, have perfectly functional genitalia. This additional feature helps with the administering of stress relief.\n");
 	outputCodex("<b>Height:</b> 5’4”</i>");
 	outputCodex("\n<b>Weight:</b> 60 kg.");
 	outputCodex("\n<b>Hair:</b> V-Ko IV nursedroids are available with any length, color, or style of hair.");
 	outputCodex("\n<b>Eyes:</b> Just like their hair, their eyes can come in any color. However, they all have the cross-shaped identification patterns in the center of their ocular receptors, to stop them being confused with other kinds of synthetics.");
-	outputCodex("\n<b>Skin:</b> V-Ko IV’s have the same synthflesh as the first generation V-Ko models with self-heating functionality, nearly identical in texture to terran skin. Their skin is always a ivory white to aid in identification. Similar to the original model, their clothes are modified synthflesh designed to appear as garments.\n\n");
+	outputCodex("\n<b>Skin:</b> V-Ko IV’s have the same synthflesh as the first generation V-Ko models with self-heating functionality, nearly identical in texture to terran skin. Their skin is always a ivory white to aid in identification. Similar to the original model, their clothes are modified synthflesh designed to appear as garments.");
+	outputCodex("\n\n");
 	outputCodex(blockHeader("Sexual Characteristics"));
-	outputCodex("V-Ko IV’s have a marked difference from the original V-Ko line, in that they possess distinct sexual characteristics. They have distinctive breasts and either a hidden or visible synthetic vagina and anus. These are both designed to be highly controllable, pliable, and self-lubricating, allowing for intercourse with a variety of species. Not only that, their vagina can be removed for hand-held use like an onahole, or even attached as an extension to the ends of their JoyCords.");
-	outputCodex("\n\nWhile it appears on first glance that the V-Ko VI’s have a built-on outfit like previous models, they can in fact remove a seamless patch of fabric from each of their breasts, revealing perfectly functioning nipples. When the patch is removed, a V-Ko appears as if they are wearing a maternity top. V-Ko VI’s can lactate from their nipples, producing many kinds of milk for infant young.");
-	outputCodex("\n\nUnlike the mainline V-Ko Nursedroids, V-Ko IV’s use their JoyCords as charging extensions, able to plug them into the nearest power port. This functionality – along with the lactation capacity – is a carry-over from JoyCo’s Maia Series, carried over for mass production.\n\n");
+	outputCodex("V-Ko IV’s have a marked difference from the original V-Ko line, in that they possess distinct sexual characteristics. They have distinctive breasts and either a hidden or visible synthetic vagina and anus. These are both designed to be highly controllable, pliable, and self-lubricating, allowing for intercourse with a variety of species. Not only that, their vagina can be removed for hand-held use like an onahole, or even attached as an extension to the ends of their JoyCords.\n\nWhile it appears on first glance that the V-Ko VI’s have a built-on outfit like previous models, they can in fact remove a seamless patch of fabric from each of their breasts, revealing perfectly functioning nipples. When the patch is removed, a V-Ko appears as if they are wearing a maternity top. V-Ko VI’s can lactate from their nipples, producing many kinds of milk for infant young.\n\nUnlike the mainline V-Ko Nursedroids, V-Ko IV’s use their JoyCords as charging extensions, able to plug them into the nearest power port. This functionality – along with the lactation capacity – is a carry-over from JoyCo’s Maia Series, carried over for mass production.");
+	outputCodex("\n\n");
 	outputCodex(blockHeader("Virtual Intelligence"));
-	outputCodex("V-Ko IV’s are Virtual Intelligences, just like previous models. However, with an additional fifty million extra lines of code programmed in, they act far more organic than their predecessors, possessing a more fluid and personable bedside manner. They still fall well short of an AI-D in terms of functionality, and possess no embedded sentience libraries.\n\n");
-	outputCodex("V-Ko IV’s are incredibly honest by nature. They are functionally incapable of lying, completely lacking the programming that allows them to do so. They can, however, still keep patient confidentiality.\n\n");
+	outputCodex("V-Ko IV’s are Virtual Intelligences, just like previous models. However, with an additional fifty million extra lines of code programmed in, they act far more organic than their predecessors, possessing a more fluid and personable bedside manner. They still fall well short of an AI-D in terms of functionality, and possess no embedded sentience libraries.\n\nV-Ko IV’s are incredibly honest by nature. They are functionally incapable of lying, completely lacking the programming that allows them to do so. They can, however, still keep patient confidentiality.");
+	outputCodex("\n\n");
 	outputCodex(blockHeader("Abilities"));
-	outputCodex("Just like the original models, V-Ko IV’s are designed to provide low-cost medical healthcare in places where proper hospitals are in short supply. They possess the same miniature medicine producing machinery inside their torsos, acting as a portable mini-hospital.");
-	outputCodex("\n\nNoticeably different, however, is their ability to deliver medical treatment through a range of means, from medicine-delivering kisses to dermal-penetrating aerosol blasts from their tail-tips. This functionality allows them to give treatment in a range of relaxing or pleasurable methods, or even when pinning the patient down with their arms and legs.");
-	outputCodex("\n\nCustomer feedback surveys have shown users are overwhelmingly pleased with the new series’s bedside manner.");
-	outputCodex("\n\nAlso different is the sexual relief functionality programmed into the V-Ko IV’s. These programs were cut and carried over from other profitable lines such as the Maia Series VI’s, saving on development time and money.\n\n");
+	outputCodex("Just like the original models, V-Ko IV’s are designed to provide low-cost medical healthcare in places where proper hospitals are in short supply. They possess the same miniature medicine producing machinery inside their torsos, acting as a portable mini-hospital.\n\nNoticeably different, however, is their ability to deliver medical treatment through a range of means, from medicine-delivering kisses to dermal-penetrating aerosol blasts from their tail-tips. This functionality allows them to give treatment in a range of relaxing or pleasurable methods, or even when pinning the patient down with their arms and legs.\n\nCustomer feedback surveys have shown users are overwhelmingly pleased with the new series’s bedside manner.\n\nAlso different is the sexual relief functionality programmed into the V-Ko IV’s. These programs were cut and carried over from other profitable lines such as the Maia Series VI’s, saving on development time and money.");
+	outputCodex("\n\n");
 	outputCodex(blockHeader("Custom Modifications"));
-	outputCodex("As with most of their product lines, JoyCo allows for a number of custom modifications to the V-Ko IV’s. Many well-off users purchase these models to rebuild from scratch, particularly as aphrodisiac-dispensing fuck-toys.");
-	outputCodex("\n\nThere are reports of V-Ko IV’s being used in illegal industries to administer mind-controlling drugs to slaves or junkies, taking advantage of their affordable cost and drug-making functions.");
-	outputCodex("\n\nThe most popular modification to make to a V-Ko IV is to install a pleasure-reward interface, allowing a unit to feel a digital approximation of sexual pleasure during intercourse. This modification is not officially sanctioned by JoyCo, as repeated use of this interface may corrupt a VI’s subroutines.");
+	outputCodex("As with most of their product lines, JoyCo allows for a number of custom modifications to the V-Ko IV’s. Many well-off users purchase these models to rebuild from scratch, particularly as aphrodisiac-dispensing fuck-toys.\n\nThere are reports of V-Ko IV’s being used in illegal industries to administer mind-controlling drugs to slaves or junkies, taking advantage of their affordable cost and drug-making functions.\n\nThe most popular modification to make to a V-Ko IV is to install a pleasure-reward interface, allowing a unit to feel a digital approximation of sexual pleasure during intercourse. This modification is not officially sanctioned by JoyCo, as repeated use of this interface may corrupt a VI’s subroutines.");
 	outputCodex("\n\n");
 	CodexManager.viewedEntry("V-Ko IVs");
 }
@@ -1370,26 +1365,46 @@ public function myrFungusCodex():void
 public function crystalGooCodexEntry():void
 {
 	clearOutputCodex();
-	showBust("GOOCUBATOR"); // 9999 - Placeholder!
+	showBust("GOOCUBATOR");
 	outputCodex(header("Ganrael"));
 	outputCodex("<b>Name (Singular & Plural):</b> Ganrael");
-	outputCodex("\n<b>Sexes:</b> PLACEHOLDER");
-	outputCodex("\n<b>Height:</b> PLACEHOLDER");
-	outputCodex("\n<b>Weight:</b> PLACEHOLDER");
-	outputCodex("\n<b>Hair & Fur:</b> PLACEHOLDER");
-	outputCodex("\n<b>Eyes:</b> PLACEHOLDER");
-	outputCodex("\n\n");
-	outputCodex(blockHeader("Features"));
-	outputCodex("PLACEHOLDER");
-	outputCodex("\n\n");
-	outputCodex(blockHeader("Environs Typically Inhabited"));
-	outputCodex("PLACEHOLDER");
-	outputCodex("\n\n");
-	outputCodex(blockHeader("Reproduction"));
-	outputCodex("PLACEHOLDER");
-	outputCodex("\n\n");
-	outputCodex(blockHeader("History"));
-	outputCodex("PLACEHOLDER");
+	outputCodex("\n<b>Sexes:</b> Monogendered");
+	outputCodex("\n<b>Height:</b> 5 to 6 feet. Some exceptional specimens can reach up to eight feet of height, though their dietary requirements to maintain such mass makes such individuals exceedingly rare.");
+	outputCodex("\n<b>Senses:</b> As goo-type creatures, the Ganrael have very limited perceptive organs. They are capable of 360 degree sight and have acute senses of smell and hearing. Most ganrael, will affect humanoid eyes and ears as part of their limited shapeshifting, in order to appear more familiar and appealing to their mates.");
+	// Gardeford
+	if(silly)
+	{
+		outputCodex("\n<b>Skin:</b> Ganrael come in a variety of colors, ranging from viridian (the most common), through red, purple, dark blues, and rarely brighter shades of yellow, orange, and pink.");
+		outputCodex("\n\n");
+		outputCodex(blockHeader("Combat"));
+		outputCodex("Unlike many goo creatures, the ganrael are not stealth predators, but prefer to openly challenge their opponents. This shift in tactics compared to similar species is likely based in the ganrael’s unique evolutionary adaptation: armor. Species like the rahn and galotians are completely soft-bodied, constantly keeping their gooey extremities saturated with liquid to maintain their easy range of motion and shape-shifting abilities, with varying levels of penetrable dermises. Ganrael instead have adapted to slowly dry out and harden their outermost layers of goo, which eventually crystallizes into a nearly diamond-hard armor plating around the subject.\n\nThis hardened outer armor protects the otherwise vulnerable ganrael inside, allowing it to engage in direct combat against even armed foes, such as the myrmedion who live in the upper caverns above the ganraels’ natural habitat. This crystal armor regenerates quickly with focus and food consumption on the part of the ganrael, and can even be adapted to grow semi-organic weapons for use: many ganrael hunt with crystal daggers, axes, or spears.");
+		outputCodex("\n\n");
+		outputCodex(blockHeader("Environs Typically Inhabited"));
+		outputCodex("Ganrael are natives of Myrellion, specifically the deepest caverns on the planet. Most live their entire lives without ever seeing the surface, though thanks to the abundance of bioluminescent fungus and creatures within the deep caves the ganrael retain their ability to see in low to high lighting. Ganrael prefer wet, humid areas in the caves, particularly those near underground lakes, rivers, and thermal vents.");
+		outputCodex("\n\n");
+		outputCodex(blockHeader("Reproduction"));
+		outputCodex("Ganrael, like most goo creatures, have distinctly non-mammalian reproduction patterns. Though some ganrael will adapt the appearance of one gender or the other, they are fundamentally a mono-gendered race, with any individual capable of bearing children. When a ganrael is ready to mate and bear children, it need only acquire the genetic material of another compatible creature -- male or female, semen or any other form of genetic carrier. The genetic material can then be absorbed through the skin (or, more commonly, inserted into the bearer through penetrative sex). Ganrael have several erogenous zones in their natural forms, and usually shift these to more traditional areas when mimicking humanoid shapes so that both the ganrael and its mate can enjoy the proceedings.\n\nOnce proper genetic material has been absorbed, the ganrael’s reproductive cycle begins. Over the course of the next 24 hours, the ganrael will begin to divide its cells, with half of the resultant cells carrying the new genetic material mixed with the parents’. The parent ganrael will shed its crystal armor and effectively split in two, resulting in a smaller (some say younger) copy of the parent along with a fully-formed child. Both parent and child are fairly weak for the next few days, requiring some time to gather their energy and eat enough to begin restoring their full size and armor plating. Between “insemination” and the resultant ganrael being fit to hunt again, perhaps a full week has passed.");
+		outputCodex("\n\n");
+		outputCodex(blockHeader("Culture & Society"));
+		outputCodex("Most ganrael are nomadic, moving through the caverns in pursuit of game and mates. There are relatively few ganrael settlements and little in the way of organized civilization. At best, a family unit of a mated pair and their children may stay together until the children are old enough to hunt on their own, at which point the family usually disintegrates. Ganrael are, as a rule, individualists who struggle to work together with other creatures (of their own race or others), which has prevented any sort of organized ganrael society from cropping up over the years.");
+	}
+	// Zeikfried
+	else
+	{
+		outputCodex("\n<b>Skin:</b> Ganrael come in a variety of colors, ranging from green (the most common), through red, pink, purple, and dark blues. Rarely, some specimens of yellow or orange coloration have been seen, though they appear to be vastly in the minority.");
+		outputCodex("\n\n");
+		outputCodex(blockHeader("Combat"));
+		outputCodex("Unlike many goo creatures, the ganrael are not stealth predators, but prefer to openly challenge their opponents. This shift in tactics compared to similar species is likely based in the ganrael’s unique evolutionary adaptation: armor. Species like the rahn and galotians are completely soft-bodied, constantly keeping their gooey extremities saturated with liquid to maintain their easy range of motion and shape-shifting abilities, with varying levels of penetrable dermises. Ganrael instead have adapted to slowly dry out and harden their outermost layers of goo, which eventually crystallizes into a nearly diamond-hard armor plating around the subject.\n\nThis hardened outer armor protects the otherwise vulnerable ganrael inside, allowing it to engage in direct combat against even armed foes, such as the myrmedion who live in the upper caverns above the ganraels’ natural habitat. Crystal armor regenerates quickly with focus and food consumption on the part of the ganrael, and can even be adapted to grow semi-biological weapons for use: many ganrael hunt with crystal daggers, axes, or spears.");
+		outputCodex("\n\n");
+		outputCodex(blockHeader("Environs Typically Inhabited"));
+		outputCodex("Ganrael are natives of Myrellion, specifically the deepest caverns on the planet. Most live their entire lives without seeing the surface, though thanks to the abundance of bioluminescent cave fungus and creatures within the deep caves the ganrael retain their ability to see in light. Ganrael prefer wet, humid areas in the caves, particularly those near underground lakes, rivers, and thermal vents.");
+		outputCodex("\n\n");
+		outputCodex(blockHeader("Reproduction"));
+		outputCodex("Ganrael, like most goo creatures, have distinctly non-mammalian reproduction patterns. Though some ganrael will adapt the appearance of one gender or the other, they are fundamentally a mono-gendered race, with any individual capable of bearing children. When a ganrael is ready to mate and bear children, it need only acquire the genetic material of another compatible creature - male or female, semen or other form of genetic carrier. The genetic material can then be absorbed through the skin (or, more commonly, inserted into the bearer through penetrative sex). Ganrael have several erogenous zones in their natural form, and usually shift these to more traditional areas when mimicking humanoid shape so that both the ganrael and its mate can enjoy the proceedings.\n\nOnce proper genetic material has been absorbed, the ganrael’s reproductive cycle begins. Over the course of the next 24 hours, the ganrael will begin to divide its cells, with half of the resultant cells carrying the new genetic material mixed with the parent’s. The parent ganrael will shed its crystal armor and effectively split in two, resulting in a smaller (some say younger) copy of the parent along with a fully-formed child. Both parent and child are fairly weak for the next few days, requiring some time to gather their energy and eat enough to begin restoring their full size and armor plating. Between “insemination” and the resultant ganrael being fit to hunt again, perhaps a full week has passed.");
+		outputCodex("\n\n");
+		outputCodex(blockHeader("Culture & Society"));
+		outputCodex("Most ganrael are nomadic, moving through the caverns in pursuit of game and mates. There are relatively few ganrael settlements and little in the way of organized civilization. At best, a family unit of a mated pair of their children may stay together until the children are old enough to hunt on their own, at which point the family usually disintegrates. Ganrael are, as a rule, individualists who struggle to work together with other creatures (of their own race or others), which has made organized ganrael societies rare, and keeps them relatively small and insignificant.");
+	}
 	outputCodex("\n\n");
 	CodexManager.viewedEntry("Ganrael");
 }

--- a/includes/CodexEntries.as
+++ b/includes/CodexEntries.as
@@ -530,7 +530,7 @@ public function rahnCodexEntry():void
 public function saeriCodexEntry():void
 {
 	clearOutputCodex();
-	showBust("9999");
+	showBust("INESSA");
 	outputCodex(header("Saeri"));
 	outputCodex("<i>Butterfly girls. Second form of caterpillar-like siel.</i>\n\n");
 	outputCodex("<b>Name (Singular):</b> Saeri");

--- a/includes/events/karaquest2/content.as
+++ b/includes/events/karaquest2/content.as
@@ -1882,6 +1882,8 @@ public function kq2ShadePCVictoryKaraNotHard():void
 	output("\n\n<i>“Ah, fuck,”</i> Shade groans, sitting back against the wall. <i>“I’m getting too old for this shit.”</i>");
 	
 	output("\n\n<i>“Stay down,”</i> Kara warns, racking the charger on her pistol. The huntress doesn’t challenge her threat, and Kara turns to you. <i>“C’mon, [pc.name], let’s go! We’re almost home free!”</i>\n\n");
+	
+	flags["KQ2_SHADE_UNCONSCIOUS"] = 1;
 
 	CombatManager.genericVictory();
 }
@@ -2059,7 +2061,7 @@ public function kq2EncounterAmara():void
 	if (flags["KQ2_SHADE_ENCOUNTERED"] != undefined)
 	{
 		output(", past Shade’s");
-		if (flags["KQ2_SHADE_DEAD"] == 1) output(" smouldering corpse")
+		if (flags["KQ2_SHADE_DEAD"] != undefined) output(" smouldering corpse")
 		else if (flags["SEXED_SHADE"] != undefined) output(" aborted ambush"); // Fucked Shade- you don't fight her so
 		else output(" failed ambush");
 	}

--- a/includes/events/karaquest2/roomFunctions.as
+++ b/includes/events/karaquest2/roomFunctions.as
@@ -669,7 +669,7 @@ public function kq2rfHelipadElevator():Boolean
 {
 	output("The elevator connects three floors of the Black Void base: the main level, the research level below, and a helipad on the roof.");
 	
-	if (flags["KQ2_DEFEATED_JUGGERNAUT"] == 1)
+	if (flags["KQ2_DEFEATED_JUGGERNAUT"] != undefined)
 	{
 		output("\n\nThe roof's been caved in, and a dead pirate in massive armor lies on the floor of the car. You're amazed the elevator is still functional.");
 	}
@@ -685,7 +685,7 @@ public function kq2rfLobbyElevator():Boolean
 {
 	output("The elevator connects three floors of the Black Void base: the main level, the research level below, and a helipad on the roof.");
 
-	if (flags["KQ2_DEFEATED_JUGGERNAUT"] == 1)
+	if (flags["KQ2_DEFEATED_JUGGERNAUT"] != undefined)
 	{
 		output("\n\nThe roof's been caved in, and a dead pirate in massive armor lies on the floor of the car. You're amazed the elevator is still functional.");
 	}
@@ -701,7 +701,7 @@ public function kq2rfLobbyElevator():Boolean
 public function kq2rfLab1():Boolean
 {
 	output("A stark white laboratory sits just outside the elevator room. Everything here is sleek, high technology bathed in sterile light");
-	if (flags["KQ2_DEFEATED_JUGGERNAUT"] == 1) output(", though much of the equipment has been torn apart by the Juggernaut’s gunfire");
+	if (flags["KQ2_DEFEATED_JUGGERNAUT"] != undefined) output(", though much of the equipment has been torn apart by the Juggernaut’s gunfire");
 	output(". A hatch sits against the eastern wall, sealed from your side by a large circular handle. A warning painted in big, red letters advises against going through without <i>“proper safety equipment”</i> - whatever that is - and that nothing may come or go through the door ahead without thorough screening.");
 
 	if (flags["KQ2_LAB1_ENTERED"] == undefined)
@@ -733,7 +733,7 @@ public function kq2rfKhansLab():Boolean
 		else output(" trying to pick up the pieces of their work, occasionally shooting their former master dark looks.");
 	}
 
-	if (flags["KQ2_WATSON_MET"] == 1 && flags["KQ2_KHANS_FILES"] == undefined)
+	if (flags["KQ2_WATSON_MET"] != undefined && flags["KQ2_KHANS_FILES"] == undefined)
 	{
 		flags["NAV_DISABLED"] = NAV_WEST_DISABLE;
 		output("\n\nYou and Kara should probably deal with Khan's files before you leave the R&D level.");
@@ -822,11 +822,11 @@ public function kq2rfRoof1():Boolean
 {
 	output("This access walkway connects the shack-like box of the elevator to the helipad to the north. Among several small shuttles, a single heavy gunship is parked there with its engines already running. Something tells you that you’re not alone up here.");
 
-	if (flags["KQ2_SHADE_UNCONSCIOUS"] == 1)
+	if (flags["KQ2_SHADE_UNCONSCIOUS"] != undefined)
 	{
 		output("\n\nShade, the kaithrit bounty hunter from back at the tavern, is lying unconscious on the ground.");
 	}
-	else if (flags["KQ2_SHADE_DEAD"] == 1)
+	else if (flags["KQ2_SHADE_DEAD"] != undefined)
 	{
 		output("\n\nShade, the kaithrit bounty hunter from back at the tavern, is lying face-down in a pool of smoking blood and plasma. Beside you, Kara looks utterly unremorseful.");
 	}
@@ -890,7 +890,7 @@ public function kq2rfLabElevator():Boolean
 	}
 
 	addDisabledButton(0, "Labs", "Research Level", "You are already on this floor.");
-	addButton(1, "Lobby", move, "KQ2_LOBBYELEVATOR");
+	addButton(1, "Lobby", move, "K2_LOBBYELEVATOR");
 	if(flags["KQ2_KHANS_FILES"] != undefined) addButton(2, "Roof", move, "K2_HELIPADELEVATOR");
 	else addDisabledButton(2, "Roof", "Helipad", "You can't go there--Kara isn't finished with what she has to do here yet!");
 

--- a/includes/gameStats.as
+++ b/includes/gameStats.as
@@ -2062,9 +2062,10 @@ public function displayEncounterLog(showID:String = "All"):void
 					else output2("\n<b>* Bunny Woman:</b>");
 					if(flags["TALKED_TO_SHELLY"] != undefined) output2(" Met her");
 					else output2(" Seen her");
-					if(flags["ASSISTED_SHELLY_WITH_LAYING"] != undefined) output2(", Assisted her egg laying");
 					if(flags["CAME_INSIDE_SHELLY"] != undefined) output2(", Came inside her");
 					if(flags["KNOWS_ABOUT_SHELLY_CUM_REACTION"] != undefined) output2(", Semen makes her eggs multiply!");
+					if(flags["ASSISTED_SHELLY_WITH_LAYING"] != undefined) output2("\n<b>* Shelly, Times Assisted Her Egg Laying: </b>" + flags["ASSISTED_SHELLY_WITH_LAYING"]);
+					if(flags["ASSISTED_SHELLY_WITH_INTENSE_LAYING"] != undefined) output2("\n<b>* Shelly, Intense Egg Laying Sessions, Total: </b>" + flags["ASSISTED_SHELLY_WITH_INTENSE_LAYING"]);
 				}
 				variousCount++;
 			}

--- a/includes/mhenga/naleen.as
+++ b/includes/mhenga/naleen.as
@@ -2,7 +2,6 @@
 import classes.Creature;
 import classes.Engine.Combat.DamageTypes.DamageResult;
 import classes.Engine.Combat.DamageTypes.TypeCollection;
-import classes.Items.Toys.GravCuffs;
 
 //UNLESS OTHERWISE NOTED, ALL SCENES BY SAVINOXO
 //Female Naleen Encounter
@@ -298,15 +297,10 @@ public function beatDatCatNaga():void {
 	}
 	if(pc.isLactating() && chars["PC"].milkType == GLOBAL.FLUID_TYPE_MILK) addButton(3,"Breastfeed",feedDatNaleenSumMilk);
 	else addDisabledButton(3,"Breastfeed","Breastfeed","You need to actually be lactating real milk.");
-	if(pc.hasItem(new GravCuffs()) && pc.lust() >= 33)
-	{
-		var fitsInside:Boolean = false;
-		if(enemy.hasVagina()) fitsInside = (pc.cockThatFits(enemy.vaginalCapacity(0)) >= 0);
-		else fitsInside = (pc.cockThatFits(enemy.analCapacity()) >= 0);
-		if(pc.hasCock() && fitsInside) addButton(5,"Cuff&Fuck",cuffNFuck,undefined,"Cuff & Fuck","Use your grav-cuffs to pin down [enemy.name] and have your way with [enemy.hisHer] [pc.vagOrAss]! Requires Grav-cuffs and a penis.");
-		else if(pc.hasCock()) addDisabledButton(5,"Cuff&Fuck","Cuff & Fuck","You can cuff [enemy.himHer] down, but you wouldn't be able to fit inside.");
-		else addDisabledButton(5,"Cuff&Fuck","Cuff & Fuck","You need a penis to make use of your grav-cuffs this way.");
-	}
+	
+	//Cuff&Fuck
+	cuffNFuckButton(5, enemy);
+	
 	addButton(14,"Leave",CombatManager.genericVictory);
 }
 /*

--- a/includes/mhenga/vanae.as
+++ b/includes/mhenga/vanae.as
@@ -419,12 +419,9 @@ public function vanaePCVictory():void
 
 			// [Vaginal Sex] [Tit Fuck] [Nipple Fuck] [Squirt & Jerk] [Cunnilingus] 
 			// [Sixty Nine - BJ] [Sixty Nine - Cunni] [Tenta Sex - Vag] [Tenta Sex - Anal] [Milk Bath]
-			var fitsInside:Boolean = false;
-			if(enemy.hasVagina()) fitsInside = (pc.cockThatFits(enemy.vaginalCapacity(0)) >= 0);
-			else fitsInside = (pc.cockThatFits(enemy.analCapacity()) >= 0);
-			if(pc.hasCock() && pc.hasItem(new GravCuffs()) && fitsInside) addButton(9,"Cuff&Fuck",cuffNFuck,undefined,"Cuff & Fuck","Use your grav-cuffs to pin down [enemy.name] and have your way with [enemy.hisHer] [pc.vagOrAssNoun]! Requires Grav-cuffs and a penis.");
-			else if(pc.hasCock() && pc.hasItem(new GravCuffs())) addDisabledButton(9,"Cuff&Fuck","Cuff & Fuck","You can cuff [enemy.himHer] down, but you wouldn't be able to fit inside.");
-			else if(pc.hasItem(new GravCuffs())) addDisabledButton(9,"Cuff&Fuck","Cuff & Fuck","You need a penis to make use of your grav-cuffs this way.");
+			
+			//Cuff&Fuck
+			cuffNFuckButton(9, enemy);
 		}
 		else
 		{
@@ -443,15 +440,8 @@ public function vanaePCVictory():void
 
 			// No requirements
 			addButton(1, "Cunnilingus", vanaeVictorySexIntro, "maiden_cunni", "Cunnilingus", "Claim her alien pussy with your mouth and eat her out.");
-			if(pc.hasItem(new GravCuffs()))
-			{
-				var fitsInside2:Boolean = false;
-				if(enemy.hasVagina()) fitsInside2 = (pc.cockThatFits(enemy.vaginalCapacity(0)) >= 0);
-				else fitsInside2 = (pc.cockThatFits(enemy.analCapacity()) >= 0);
-				if(pc.hasCock() && fitsInside2) addButton(2,"Cuff&Fuck",cuffNFuck,undefined,"Cuff & Fuck","Use your grav-cuffs to pin down [enemy.name] and have your way with [enemy.hisHer] [pc.vagOrAssNoun]! Requires Grav-cuffs and a penis.");
-				else if(pc.hasCock()) addDisabledButton(2,"Cuff&Fuck","Cuff & Fuck","You can cuff [enemy.himHer] down, but you wouldn't be able to fit inside.");
-				else addDisabledButton(2,"Cuff&Fuck","Cuff & Fuck","You need a penis to make use of your grav-cuffs this way.");
-			}
+			//Cuff&Fuck
+			cuffNFuckButton(2, enemy);
 		}
 	}
 	else

--- a/includes/mhenga/zilFemale.as
+++ b/includes/mhenga/zilFemale.as
@@ -1193,15 +1193,7 @@ public function defeatHostileZil():void {
 		addButton(9,"Capture",useTheCaptureHarness);
 		output("\n\n<b>Doctor Julian Haswell wanted you to use a capture harness on a zil. Now would be the perfect time.</b>");
 	}
-	if(pc.hasItem(new GravCuffs()) && pc.lust() >= 33)
-	{
-		var fitsInside:Boolean = false;
-		if(enemy.hasVagina()) fitsInside = (pc.cockThatFits(enemy.vaginalCapacity(0)) >= 0);
-		else fitsInside = (pc.cockThatFits(enemy.analCapacity()) >= 0);
-		if(pc.hasCock() && fitsInside) addButton(5,"Cuff&Fuck",cuffNFuck,undefined,"Cuff & Fuck","Use your grav-cuffs to pin down [enemy.name] and have your way with [enemy.hisHer] [pc.vagOrAssNoun]! Requires Grav-cuffs and a penis.");
-		else if(pc.hasCock()) addDisabledButton(5,"Cuff&Fuck","Cuff & Fuck","You can cuff [enemy.himHer] down, but you wouldn't be able to fit inside.");
-		else addDisabledButton(5,"Cuff&Fuck","Cuff & Fuck","You need a penis to make use of your grav-cuffs this way.");
-	}
+	
 	output("\n\n");
 	addButton(14,"Leave",CombatManager.genericVictory);
 }

--- a/includes/mhenga/zilMale.as
+++ b/includes/mhenga/zilMale.as
@@ -96,15 +96,6 @@ public function winVsZil():void {
 		addButton(9,"Capture",useTheCaptureHarness);
 		output("\n\n<b>Doctor Julian Haswell wanted you to use a capture harness on a zil. Now would be the perfect time.</b>");
 	}
-	if(pc.hasItem(new GravCuffs()) && pc.lust() >= 33)
-	{
-		var fitsInside:Boolean = false;
-		if(enemy.hasVagina()) fitsInside = (pc.cockThatFits(enemy.vaginalCapacity(0)) >= 0);
-		else fitsInside = (pc.cockThatFits(enemy.analCapacity()) >= 0);
-		if(pc.hasCock() && fitsInside) addButton(6,"Cuff&Fuck",cuffNFuck,undefined,"Cuff & Fuck","Use your grav-cuffs to pin down [enemy.name] and have your way with [enemy.hisHer] [pc.vagOrAssNoun]! Requires Grav-cuffs and a penis.");
-		else if(pc.hasCock()) addDisabledButton(6,"Cuff&Fuck","Cuff & Fuck","You can cuff [enemy.himHer] down, but you wouldn't be able to fit inside.");
-		else addDisabledButton(6,"Cuff&Fuck","Cuff & Fuck","You need a penis to make use of your grav-cuffs this way.");
-	}
 	addButton(14,"Leave",CombatManager.genericVictory);
 }
 

--- a/includes/myrellion/crystalGoo.as
+++ b/includes/myrellion/crystalGoo.as
@@ -16,7 +16,7 @@ public function crystalGooFenBurps():void
 	author("Gardeford");
 	showGardeGoo();
 	
-	var gooKnight:Creature = new GooKnight()
+	var gooKnight:Creature = new GooKnight();
 	setEnemy(gooKnight);
 	
 	//load encounter to determine color, for reasons.

--- a/includes/myrellion/crystalGoo.as
+++ b/includes/myrellion/crystalGoo.as
@@ -11,14 +11,14 @@ public function showGooKeep():void
 }
 
 //Crystal goo knight encounter
-/*
 public function crystalGooFenBurps():void
 {
 	author("Gardeford");
 	showGardeGoo();
 	
-	setEnemy(new CrystalKnight());
-
+	var gooKnight:Creature = new GooKnight()
+	setEnemy(gooKnight);
+	
 	//load encounter to determine color, for reasons.
 	if(flags["MET_GOO_KNIGHT"] == undefined)
 	{
@@ -39,9 +39,16 @@ public function crystalGooFenBurps():void
 		output("\n\nYou hear clanking on the rocks just in time to avoid a slash from a ganraen knight. It looks like you’re a popular choice for their attacks. You ready your weapons and prepare to fight.");
 	}
 	clearMenu();
-	//addButton(0,"Next",startCombatLight);
+	
+	CombatManager.newGroundCombat();
+	CombatManager.setFriendlyCharacters(pc);
+	CombatManager.setHostileCharacters(gooKnight);
+	CombatManager.victoryScene(beatUpCrystalGoo);
+	CombatManager.lossScene(gooKnightLossRouter);
+	CombatManager.displayLocation("GOO KNIGHT");
+	
+	addButton(0,"Next",CombatManager.beginCombat);
 }
-*/
 
 public function gooKnightLossRouter():void
 {
@@ -474,7 +481,11 @@ public function gooVillageThinger():void
 	output(", and you shield yourself as numerous heavy plates clang down atop you. Once the cacophony ends you have a little time to recover your bearings, calming your breathing as you hold what you now see are multicolored crystals above your head.");
 	output("\n\nSuddenly, the plates covering you liquefy, coating you in more of the sticky goo that covered the passage. You do your best to wipe it from your eyes, blinking the last of it away to find out what happened. A group of variably colored goo-girls - and some with male forms as well - surround you, staring on with wide-eyed, apprehensive expressions. Your codex gives a slime-muffled beep to tell you that these are ganrael, ");
 	if(CodexManager.entryUnlocked("Ganrael")) output("but you already knew that");
-	else output("a race of crystal forming goos");
+	else
+	{
+		output("a race of crystal forming goos");
+		CodexManager.unlockEntry("Ganrael");
+	}
 	output(".");
 	output("\n\nYou look around, noticing a number of small huts formed from crystalline panels. A bad feeling about the gemstone plates that covered you crosses your mind before the sticky gel that covers you solidifies, trapping you in place. The formerly surprised expressions shift to annoyed glares as your new captors close in around you. An orange-colored girl with a braid secured by citrines looms over you, and the others halt.");
 	output("\n\n<i>“You knocked over my house,”</i> she states with heated fervor. Her frame looks incredibly tense for being less than fully solid, and she gives you a soul withering frown. The rest of her kin shake their heads and furrow their brows, looking ready to deliver mob justice. Heat flushes through your face as you try to think of a way out.");
@@ -735,6 +746,7 @@ public function visitCrystalGooShop():void
 	else output("clap happily, wondering which of the blobs you should get");
 	output(".");
 	flags["MET_CGOO_SHOPKEEP"] = 1;
+	CodexManager.unlockEntry("Ganrael");
 	//The shopkeeps wares include purple, yellow, orange, green, black, red, blue, white, and pink. alternating every day in groups of 4
 	//[buy goo ball][talk][leave]
 	clearMenu();

--- a/includes/myrellion/karaAndShade.as
+++ b/includes/myrellion/karaAndShade.as
@@ -1142,6 +1142,7 @@ public function shadeQuestNeedsTurnIn():Boolean
 }
 public function shadeAtTheBar():Boolean
 {
+	if(flags["SHADE_ON_UVETO"] != undefined && flags["KQ2_QUEST_OFFER"] != undefined && flags["KQ2_QUEST_FINISHED"] == undefined) return false; //9999 Shade does not show up during Kara Quest 2 if she's on Uveto. REMOVE THIS LINE AND ENABLE NEXT LINE WHEN UVETO IS ACTUALLY IMPLEMENTED.
 	//9999 if(flags["SHADE_ON_UVETO"] != undefined) return false;
 	if(flags["SHADE_AND_KARA_RESOLVED_THINGS_THEMSELVES"] != undefined) return false;
 	if(flags["SHADE_DEFEATED_WITH_KARA"] != undefined) return false;

--- a/includes/myrellion/myrDeserterIndividuals.as
+++ b/includes/myrellion/myrDeserterIndividuals.as
@@ -814,15 +814,8 @@ public function winVsAntGrillDeserts():void
 			else addDisabledButton(4,"Hand-Play","Hand-Play","Tauric creatures cannot enjoy this scene.");
 		}
 		else addDisabledButton(4,"Hand-Play","Hand-Play","Only a gold myr deserter has enough hands for this scene...");
-		if(pc.hasItem(new GravCuffs()) && pc.lust() >= 33)
-		{
-			var fitsInside:Boolean = false;
-			if(enemy.hasVagina()) fitsInside = (pc.cockThatFits(enemy.vaginalCapacity(0)) >= 0);
-			else fitsInside = (pc.cockThatFits(enemy.analCapacity()) >= 0);
-			if(pc.hasCock() && fitsInside) addButton(5,"Cuff&Fuck",cuffNFuck,undefined,"Cuff & Fuck","Use your grav-cuffs to pin down [enemy.name] and have your way with [enemy.hisHer] [pc.vagOrAssNoun]! Requires Grav-cuffs and a penis.");
-			else if(pc.hasCock()) addDisabledButton(5,"Cuff&Fuck","Cuff & Fuck","You can cuff [enemy.himHer] down, but you wouldn't be able to fit inside.");
-			else addDisabledButton(5,"Cuff&Fuck","Cuff & Fuck","You need a penis to make use of your grav-cuffs this way.");
-		}
+		//Cuff&Fuck
+		cuffNFuckButton(5, enemy);
 	}
 	else
 	{

--- a/includes/myrellion/nyrea.as
+++ b/includes/myrellion/nyrea.as
@@ -541,19 +541,9 @@ public function pcVictoryOverNyrea():void
 	addButton(1, "Ride Cock", rideNyreaDick);
 	if (pc.hasTailCock()) addButton(2, "Docking", nyreaTailcockDocking); //Needs a tailcock less than 3 inches thick. Length is irrelevant.
 	else addDisabledButton(2, "Docking", "Docking", "Requires a tailcock.");
+	//Cuff&Fuck
+	cuffNFuckButton(3, enemy);
 	
-	if(pc.hasItem(new GravCuffs()) && pc.lust() >= 33)
-	{
-		var fitsInside:Boolean = false;
-		if(enemy.hasVagina()) fitsInside = (pc.cockThatFits(enemy.vaginalCapacity(0)) >= 0);
-		else fitsInside = (pc.cockThatFits(enemy.analCapacity()) >= 0);
-
-		if(pc.hasCock() && fitsInside) addButton(3,"Cuff&Fuck",cuffNFuck,undefined,"Cuff & Fuck","Use your grav-cuffs to pin down [enemy.name] and have your way with [enemy.hisHer] [pc.vagOrAssNoun]! Requires Grav-cuffs and a penis.");
-		else if(pc.hasCock()) addDisabledButton(3,"Cuff&Fuck","Cuff & Fuck","You can cuff [enemy.himHer] down, but you wouldn't be able to fit inside.");
-		else addDisabledButton(3,"Cuff&Fuck","Cuff & Fuck","You need a penis to make use of your grav-cuffs this way.");
-		//output(" CUFFIES");
-	}
-	//else output(" NO CUFFIES");
 	// 9999 territory - need something decent for leaving after victory without fucking
 	addButton(14, "Leave", function():void {
 		clearOutput();

--- a/includes/myrellion/roomFunctions.as
+++ b/includes/myrellion/roomFunctions.as
@@ -794,8 +794,8 @@ public function DeepCavesBonus():Boolean
 		choices[choices.length] = infectedMyrmedionShit;
 		if(silly)
 		{
-			//choices[choices.length] = crystalGooFenBurps;
-			//choices[choices.length] = crystalGooFenBurps;
+			choices[choices.length] = crystalGooFenBurps;
+			choices[choices.length] = crystalGooFenBurps;
 			//crystalGooFenBurps();
 			//return true;
 		}

--- a/includes/roomFunctions.as
+++ b/includes/roomFunctions.as
@@ -566,6 +566,7 @@ public function bonusFunction213():Boolean
 	return false;
 }
 
+/*
 public function novaShipHangarElevator():Boolean
 {
 	if (flags["DECK13_COMPLETE"] == undefined)
@@ -578,6 +579,7 @@ public function novaShipHangarElevator():Boolean
 	}
 	return false;
 }
+*/
 
 public function novaMainDeckElevator():Boolean
 {
@@ -585,6 +587,12 @@ public function novaMainDeckElevator():Boolean
 	{
 		output("\n\nYou step up to the elevator and press the call button. The doors don’t respond.");
 		output("\n\nHm. The shaft must have been destroyed when the planet blew up, sealing the doors indefinitely....");
+		
+		return false;
+	}
+	if (flags["DECK13_COMPLETE"] == undefined)
+	{
+		output("\n\nYou step up to the elevator and press the call button. Immediately, the doors slide open, but no car comes.");
 		
 		return false;
 	}
@@ -609,7 +617,7 @@ public function novaElevatorControlPanel():void
 	if (currentLocation != "NOVA MAIN DECK ELEVATOR") addButton(0, "Main Deck", move, "NOVA MAIN DECK ELEVATOR");
 	else addDisabledButton(0, "Main Deck");
 	
-	if (currentLocation != "DECK 13 ELEVATOR SHAFT" && ((flags["ANNO_MISSION_OFFER"] >= 2 && flags["ANNO_MISSION_OFFER"] != undefined) || flags["DECK13_COMPLETE"] == 1)) addButton(1, "Deck 13", move, "DECK 13 ELEVATOR SHAFT");
+	if (currentLocation != "DECK 13 ELEVATOR SHAFT") addButton(1, "Deck 13", move, "DECK 13 ELEVATOR SHAFT");
 	else addDisabledButton(1, "Deck 13");
 	
 	addButton(14, "Back", mainGameMenu);

--- a/includes/tarkus/raskvelFemaleFight.as
+++ b/includes/tarkus/raskvelFemaleFight.as
@@ -123,15 +123,8 @@ public function victoryVsRaskvel():void
 			output(" If you had a pussy, you could ride her face. Sadly, you don't.");
 			addDisabledButton(2,"RideHerFace");
 		}
-		if(pc.hasItem(new GravCuffs()) && pc.lust() >= 33)
-		{
-			var fitsInside:Boolean = false;
-			if(enemy.hasVagina()) fitsInside = (pc.cockThatFits(enemy.vaginalCapacity(0)) >= 0);
-			else fitsInside = (pc.cockThatFits(enemy.analCapacity()) >= 0);
-			if(pc.hasCock() && fitsInside) addButton(3,"Cuff&Fuck",cuffNFuck,undefined,"Cuff & Fuck","Use your grav-cuffs to pin down [enemy.name] and have your way with [enemy.hisHer] [pc.vagOrAssNoun]! Requires Grav-cuffs and a penis.");
-			else if(pc.hasCock()) addDisabledButton(3,"Cuff&Fuck","Cuff & Fuck","You can cuff [enemy.himHer] down, but you wouldn't be able to fit inside.");
-			else addDisabledButton(3,"Cuff&Fuck","Cuff & Fuck","You need a penis to make use of your grav-cuffs this way.");
-		}
+		//Cuff&Fuck
+		cuffNFuckButton(3, enemy);
 	}
 	else
 	{

--- a/includes/tavros/inessa.as
+++ b/includes/tavros/inessa.as
@@ -1,4 +1,6 @@
-﻿/*Inessa and the Happy Tails
+﻿import classes.Items.Toys.GravCuffs;
+
+/*Inessa and the Happy Tails
 By JimThermic
 
 Concept
@@ -1149,7 +1151,7 @@ public function cuffNFuck():void
 	//Random text output (⅓ chance):
 	if(rand(3) == 0)
 	{
-		output("\n\n <i>“W-what’s going on--?”</i> [enemy.name] stammers. [enemy.HeShe] tries to pull [enemy.hisHer] [enemy.skinColor] hands off the ground, but [enemy.heShe] can’t budge an inch.");
+		output("\n\n<i>“W-what’s going on--?”</i> [enemy.name] stammers. [enemy.HeShe] tries to pull [enemy.hisHer] [enemy.skinColor] hands off the ground, but [enemy.heShe] can’t budge an inch.");
 		output("\n\nStriding up to your prostrate opponent, you stroke [enemy.hisHer] butt and give it a ");
 		if(pc.isNice()) output("playful pat");
 		else if(pc.isMischievous()) output("cheeky slap");
@@ -1238,7 +1240,7 @@ public function cuffNFuck():void
 	output(".");
 
 	output("\n\n<i>“");
-	if(rand(5) == 0) output("Did you just cum?”</i>");
+	if(rand(5) == 0) output("Did you just cum?");
 	else if(rand(4) == 0) output("Funny, I swear you just came just then.");
 	else if(rand(3) == 0) output("Weren’t you just saying you weren’t enjoying yourself? Such a liar!");
 	else if(rand(2) == 0) output("You just came around my [pc.cockNoun " + x + "] - how did it feel?");
@@ -1264,7 +1266,8 @@ public function cuffNFuck():void
 		else output("bowels until they are");
 		output(" filled with your seed.");
 	}
-	else if(pc.cumQ() < 4000) {
+	else if(pc.cumQ() < 4000)
+	{
 		output("A font of [pc.cumNoun] surges from your cock-tip and quickly fills up [enemy.hisHer] ");
 		if(enemy.hasVagina()) output("[enemy.pussy] and womb");
 		else output("bowels");
@@ -1289,6 +1292,14 @@ public function cuffNFuck():void
 		else output("out of [enemy.hisHer] [enemy.vagOrAss]");
 	}
 	output(".");
+	
+	// NPC Pregnancy handling
+	if(enemy.hasVagina())
+	{
+		if(enemy is RaskvelFemale) knockUpRaskChance();
+		if(enemy is MyrRedFemaleDeserter) knockUpRedBitchChance();
+	}
+	
 	processTime(33);
 	pc.orgasm();
 	enemy.orgasm();

--- a/includes/tavros/shelly.as
+++ b/includes/tavros/shelly.as
@@ -1,10 +1,11 @@
 ﻿import classes.Items.Miscellaneous.SmallEgg;
 
-public function shellyDisplay():void
+public function shellyDisplay(nude:Boolean = false):void
 {
-	if(flags["KNOW_SHELLYS_NAME"] == undefined) userInterface.showName("BUNNY\nWOMAN");
-	else userInterface.showName("\nSHELLY");
-	userInterface.showBust("SHELLY");
+	if(flags["KNOW_SHELLYS_NAME"] == undefined) showName("BUNNY\nWOMAN");
+	else showName("\nSHELLY");
+	if(!nude) showBust("SHELLY");
+	else showBust("SHELLY_NUDE");
 	author("Gardeford");
 }
 
@@ -58,6 +59,12 @@ public function investigateSlashShelly():void
 	{
 		if(pc.hasCock() && pc.lust() >= 33) addButton(2,"Sex",sexWithShelly);
 		else addDisabledButton(2,"Sex","Sex","Sex with Shelly requires both a phallus and lust to be at or above 33.");
+		
+		if(flags["ASSISTED_SHELLY_WITH_LAYING"] >= 3)
+		{
+			if(silly) addButton(6,"Assist+",shellyIntenseEggLaying,undefined,"Uneggspected Eggspelling in Eggcess","<i><b>Really</b></i> help Shelly lay some eggs. <i>Eggcelsior!</i>");
+			else addButton(6,"Assist+",shellyIntenseEggLaying,undefined,"Intense Egg Laying Session","<i><b>Really</b></i> help Shelly lay some eggs.");
+		}
 	}
 	else addDisabledButton(2,"Sex","Sex","Shelly isn't interested in sex unless you've already \"Assist\"ed her.");
 	addButton(14,"Leave",mainGameMenu);
@@ -77,7 +84,7 @@ public function talkToShelly():void
 	output("\n\nYou chuckle, telling her that part of her problem might be people thinking she’s just pregnant in a bar. She frowns slightly and removes her hand.");
 	output("\n\n<i>“Yeah I guess, but you only got half the story. The trial I was in was more than a year ago. Apparently the test drug they gave me was a little too effective, so whenever these eggs come out more replace them near immediately. The drug that’s going to markets is improved, no permanent effects. They must have realized people would make that mistake like you thought though. The company gave me a job promoting the product, and it's okay money - enough to rent a room on the station,”</i> she says, sounding a little more optimistic at the end.");
 	output("\n\nYou mention that you heard her mentioning “layings” and ask what that entails. She blushes and sets the sign off to the side, weaving her fingers together and looking around to see if anyone else is listening.");
-	output("\n\n<i>“Well, so i’m full of eggs, and even though they keep coming back, laying is fairly regular. Usually it's just once every couple days, but they can be… coerced to come out sooner. If you get over the fact that they came out of a person, they taste really sweet,”</i> she says with an embarrassed smile. Without really thinking about it, you tell her you’d be happy to assist her with laying eggs if she ever wanted help. The dusky saleswoman’s pink bunny ears turn beet red as she takes in your words, and you realize what you said.");
+	output("\n\n<i>“Well, so i’m full of eggs, and even though they keep coming back, laying is fairly regular. Usually it's just once every couple days, but they can be... coerced to come out sooner. If you get over the fact that they came out of a person, they taste really sweet,”</i> she says with an embarrassed smile. Without really thinking about it, you tell her you’d be happy to assist her with laying eggs if she ever wanted help. The dusky saleswoman’s pink bunny ears turn beet red as she takes in your words, and you realize what you said.");
 	output("\n\n<i>“W-well, if you really wanted too, I’d be ok with it. If I just wait for it to happen, they kinda build up and get heavier. My name is Shelly by the way,”</i> she says, brushing her hair away from her face. You aren’t sure if she’s desperate or if you made that big of an impression being the only person who came up and talked to her, but it seems she’d be willing to let you help her, and all that entails. You give her your first name in return and tell her you’ll probably be back soon.");
 	flags["KNOW_SHELLYS_NAME"] = 1;
 	//pass 30 min
@@ -89,7 +96,7 @@ public function talkToShelly():void
 //Assist
 public function assistShellyLaying():void
 {
-	flags["ASSISTED_SHELLY_WITH_LAYING"] = 1;
+	IncrementFlag("ASSISTED_SHELLY_WITH_LAYING");
 	clearOutput();
 	shellyDisplay();
 	output("You tell Shelly if she wants some assistance with her egg laying, you’re available now. She nods, grinning and gripping your hand tightly as she pulls you to one of the back rooms. The room is well lit and surprisingly comfortable-looking for what you would expect from a bar like this.");
@@ -136,11 +143,12 @@ public function getShellyPregContainer():PregnancyPlaceholder
 public function sexWithShelly():void
 {
 	clearOutput();
-	shellyDisplay();
-	userInterface.showBust("SHELLY_NUDE");
+	shellyDisplay(true);
+	
 	var x:int = pc.cockThatFits(100);
 	if(x < 0) x = pc.smallestCockIndex();
 	processTime(50+rand(10));
+	
 	output("You ask Shelly if she’d be up for a little more than just egg-laying assistance. She looks confused for a moment before realization lights up her face.");
 	output("\n\n<i>“Really? You’d do that, with me?”</i> she asks, obviously happy but not totally sure.");
 	output("\n\nYou tell her there’s nothing you’d rather do more at the moment. She takes your arm, pulling you into the back room nearly bouncing on her heels. When you arrive in the comfortable looking lodging, She turns around, presses herself against you, and ");
@@ -176,7 +184,7 @@ public function sexWithShelly():void
 	else
 	{
 		output("\n\nYou silhouette the dark skinned delicacy with your hands, prodding her to bend forward in front of the bed. Shelly bends sensually, holding her pussy open with two fingers and aiming a seductive gaze at you over her shoulder. You lean your upper body over her, grasping a breast in each hand and giving her a deep kiss.");
-		output("\n\nAfter a moment you bring your tauric half up, feeling your underside brush over her smooth back till [pc.cock " + x + "] slides like a puzzle piece between her cheeks. You rub back and forth against her, letting her prepare for penetration and teasing her at the same time. She grips [pc.cock " + x + "] with the tips of her fingers, caressing the underside whenever you pull back.");
+		output("\n\nAfter a moment you bring your tauric half up, feeling your underside brush over her smooth back until [pc.cock " + x + "] slides like a puzzle piece between her cheeks. You rub back and forth against her, letting her prepare for penetration and teasing her at the same time. She grips [pc.cock " + x + "] with the tips of her fingers, caressing the underside whenever you pull back.");
 		output("\n\nYou brace yourself on the bed and look at Shelly. She's holding herself up with one elbow and smiling at you as she polishes your [pc.cockNoun " + x + "] with her hand. The sight is too much to resist, and you rearrange yourself one more time, lining [pc.cock " + x + "] up with the entrance to her vagina. Your [pc.cockHead " + x + "] pushes into her folds, penetrating her easily");
 		if(pc.cockVolume(x) <= 50) output(" til you hilt inside her");
 		else output(" til your tip bumps into her cervix");
@@ -196,8 +204,7 @@ public function sexWithShelly():void
 public function humanoidsCumOutsideShelly():void
 {
 	clearOutput();
-	shellyDisplay();
-	userInterface.showBust("SHELLY_NUDE");
+	shellyDisplay(true);
 	output("Deciding to honor her wish, you piston a few more times for build-up and then gently lay her on the bed, popping your cock out of her pussy just in time. [pc.EachCock] pulses with orgasmic bliss, spurting blasts of [pc.cum] all over her body. A few ropes reach her face, painting parts of her dusky body [pc.cumColor]. She smiles and thanks you for not cumming inside.");
 
 	//if first time: 
@@ -210,8 +217,7 @@ public function humanoidsCumOutsideShelly():void
 public function humanoidsCumInsideShelly():void
 {
 	clearOutput();
-	shellyDisplay();
-	userInterface.showBust("SHELLY_NUDE");
+	shellyDisplay(true);
 	output("Ignoring her warning, you piston several times inside her before hilting in preparation for the coming torrent. Your rapid thrusts set off her second orgasm, and you give her a kiss as her body clamps around you. Her tightened insides are too much to resist, and your dick blows its load inside her egg filled womb.");
 	if(pc.cockTotal() > 2) output(" Your other cocks spurt wildly over her legs and the underside of her stomach.");
 	else if(pc.cockTotal() == 2) output(" Your other cock spurts wildly over her legs and the underside of her stomach.");
@@ -226,8 +232,7 @@ public function humanoidsCumInsideShelly():void
 public function taursCumOutsideShelly():void
 {
 	clearOutput();
-	shellyDisplay();
-	userInterface.showBust("SHELLY_NUDE");
+	shellyDisplay(true);
 	output("Deciding to honor her wish, you thrust a few more times, popping out of her velvety box just in time. [pc.EachCock] pulses with orgasmic fervor, spurting your load over her butt and back. Your cum paints her back [pc.cumColor], and a few shots even make it to her neck. She smiles weakly and thanks you for not cumming inside.");
 	//(if first time: Curious, you ask her why not.)
 	if(flags["KNOWS_ABOUT_SHELLY_CUM_REACTION"] == undefined) output("\n\nCurious, you ask her why not.");
@@ -239,8 +244,7 @@ public function taursCumOutsideShelly():void
 public function taursCumInsideShelly():void
 {
 	clearOutput();
-	shellyDisplay();
-	userInterface.showBust("SHELLY_NUDE");
+	shellyDisplay(true);
 	output("Ignoring her warning, you piston your powerful hips a few more times, finally hilting inside her in preparation for flooding her with seed. Your thrusts start her orgasm anew, and she bites the sheets, now soaked in sugary fluids. Her tightened insides are too much to resist in the heat of the moment, and your breath catches as you’re overwhelmed by lust. Your dick pumps its load into her egg-stuffed womb.");
 	if(pc.cockTotal() > 1)
 	{
@@ -274,4 +278,94 @@ public function omniShellyEpilogueBlurb():void
 	processTime(5);
 	clearMenu();
 	addButton(0,"Next",mainGameMenu);
+}
+
+//Inside
+public function shellyIntenseEggLaying(pageNum:int = 1):void
+{
+	clearOutput();
+	shellyDisplay(true);
+	
+	if(pageNum == 1)
+	{
+		output("You ask Shelly if she’d be up for a little more intensive session of egg-laying. She cocks an eyebrow, not fully sure of your meaning, but interested enough that you think she’ll accept. After a few moments of thought she nods, pulling you into the back room she uses to lay her eggs. You follow eagerly, her sugary scent making your mouth water.");
+		output("\n\n<i>“Alright, now what’s this intensity you’re talking about?”</i> she asks, turning to face you. You tell her");
+		if(flags["ASSISTED_SHELLY_WITH_INTENSE_LAYING"] == undefined) output(" it’s a surprise, but the first egg will be coming out while she’s still standing");
+		else output(" it’s the same kind of treatment as last time");
+		output(". As you speak you");
+		if(!pc.isNude()) output(" strip from your [pc.clothes] before stepping");
+		else output(" step");
+		output(" closer to her, unhooking her denim bikini and freeing her dusky mounds.");
+		output("\n\nBeads of sugary milk have already begun to form on her nipples, and you take a slow drink from one as you work the button on her shorts. You gently tug them down over her ample booty, revealing a pair of lace panties. This time they match her hair in color, a shiny bright blue. You end your drink, letting some of the milk stay on your lips as you plant wet kisses along her egg-filled belly.");
+		output("\n\nUnder the dark mountain of her stomach you find her glistening slit. You prompt her to open her legs a little further, spreading her lips as you press your own into them. Her hard clit is like sweet candy as you roll your tongue over it, lapping up her juices with gusto. Your pleased to feel her legs quiver as you lick, and you can hear her trying to contain her voice.");
+		output("\n\nYour fingers join your lips, playing around her entrance teasingly. Your other hand reaches around her back, giving her ass a squeeze and toying with the cottony fuzz of her bunny tail. You see Shelly’s arms move out of sight above her belly, assumedly to play with her tits. Sure enough you soon see small streams of milk trickling into your vision, dripping onto your face and mixing with her other juices.");
+		output("\n\nThe egg-filled bunny girl’s candied liquids set you on a sugar high, licking her faster and faster as it increases. Your fingers now penetrate her sopping hole, and she moans as they rub the sensitive walls of her insides. The muscles of her squeezable butt tense in your hand, and you massage the dusky flesh as you work her clit.");
+		output("\n\nHer voice grows louder and louder as you continue, wobbling on her legs as her pleasure builds. She holds your head to steady herself, and you nearly lose your own footing as you’re used as a table. You grin as she shudders, and feel her entire body tensing as she cums. Her noises catch in her throat, unable to escape the spasming vessel that contains them.");
+		output("\n\n<i>“Oooooh. The first egg is c-coming,”</i> she says, her voice slurring as her balance wobbles. You hold out both hands, giving her one last lick before pulling back. In short time, a small pink egg pushes its way out of her, plopping into your hands with a small splash. Once the effort is over the strength leaves Shelly’s body, and she collapses onto the bed, holding herself up with her arms and knees.");
+		
+		processTime(10);
+		pc.milkInMouth(getShellyPregContainer());
+		pc.girlCumInMouth(getShellyPregContainer());
+		pc.lust(5);
+		clearMenu();
+		addButton(0, "Next", shellyIntenseEggLaying, 2);
+		return;
+	}
+	else if(pageNum == 2)
+	{
+		output("<i>“");
+		if(flags["ASSISTED_SHELLY_WITH_INTENSE_LAYING"] == undefined) output("Is that all? that wasn’t much different from norm");
+		else output("Yeah, this way is the be");
+		output("-ahhh,”</i> she begins, but you interrupt her before she can finish, plugging her now easily visible hole with your tongue. The remnants of her previous orgasm set her insides to clutching tightly around your oral muscle. You kiss her hole like the mouth of a lover, tonguing sensuously at its corners.");
+		output("\n\nYou give her legs a bear hug as you continue to lick her inside and out, inhaling her sugary scent like a drug. The smell is intoxicating, and every breath you take is accompanied by a twinge from your groin. Your attentions draw coos and hums from the egg-stuffed bunny, and you reach up to cup one of her dusky D-cups.");
+		output("\n\nThe chocolate colored orb is as soft as the bed she kneels on, and still dripping with a few beads of milk that let your hand coat it with a sugary sheen. Her upper arms seem to be losing their strength about as fast as her legs did, and you wonder how much longer she’ll be able to hold herself in her current position.");
+		output("\n\nBeing a curious person, you can’t help but test out such a thought. You grip both of her ebony ass-cheeks, squeezing them and spreading her wider as you intensify your treatment of her nethers. Candied juices drip from her hungry cunt, soaking the bed beneath it. Her arms wobble one more time before she falls forward, no longer able to hold against your assault.");
+		output("\n\nHer front falls, pressing into the bedding, and she buries her face in a pillow, unable to completely muffle the loud moan that comes next. You rub her burdened belly, starting at the sides of her now smushed breasts and continuing until you reach the top of her pelvis. You trace lines over her skin with your fingertips, eliciting a number of pleased noises and twitches from the happy bunny.");
+		output("\n\nYou give her a break for a moment, more to catch a breather for yourself than to give her a rest. Sticky strands of the sugary slut’s juices cling you your mouth breaking as you lick your lips, mixing with your saliva. Your tongue is coated in a similar mixture, so the sweet syrup is too thick too completely remove, and your lips cling to her irresistibly smooth butt for a moment when you kiss it.");
+		output("\n\nYou squeeze Shelly’s cute cotton tail like a sponge, giggling in your sugar induced high as the fur tickles your fingers. You blow on the base of the fuzzy thing, your giggle becoming a laugh when her cheeks clench in response. You pull back for a second, pulling off the dusky beauty’s blindingly white socks and planting a sugar slickened kiss on the sole of each foot. Her toes splay out as you do so, and you lace your fingers through them as you return your attention upward.");
+		output("\n\nOn the way you plant a smooch on the underside of the chocolate bunny’s belly, transitioning to a lick that travels up her trail of dripping juices all the way to her snatch. You’re pleased to see her clenching the bed sheets in each hand, and slow down to a tantalizing gait as your [pc.tongue] slides over her entrance.");
+		output("\n\nShelly holds her breath as she waits for your oral muscle to finish its path. What kind of person would you be if you denied her? Just as your [pc.tongue] is about to leave the top of her pussy, you dive back, plunging it as deeply as you can into her. The breath she had held sighs out, rising into an orgasmic moan as her entire body shudders.");
+		output("\n\nIt would appear that the dark skinned rabbit was holding in a lot more than you’d thought. sweetened juices splash your face as a new egg bumps into your tongue. You pull back in surprise, letting the white striped ovoid plop out of her with the next giant spasm of pleasure. You catch the new egg in your hands, placing it next to the pink one from before.");
+		output("\n\nYou don’t give the beleaguered bunny a chance to rest, flipping her over while she’s still cumming from the last bout of fun. You dive into her still clenching cunt, sucking her candied clit for a few seconds before moving on the biggest dessert. Now that she’s flipped over your [pc.tongue] has a new area of muscle to explore.");
+		output("\n\n<i>“W-wait, I’m still c-cumming!”</i> she half shouts between moans. You ignore her plea, instead opting to slather her inner thighs with kisses as they instinctively close around your head. The bright pink clit that your nose is rubbing against is blinding against the darker flesh that surrounds you.");
+		output("\n\n<i>“M-more cumming...”</i> she says, her voice trailing off into quiet moans as her body is rocked with a mind melting orgasm. The bed beneath her is soaked with milk and fem-cum, filling the air with her enticingly sweet scent. The smell of it batters through your self restraint, urging you to let your licks last longer and longer.");
+		output("\n\nYou gently massage her egg-filled midsection, coaxing it with touches to release another into your safe keeping. You pause periodically to give her breasts a rough squeeze, the coating of milk making them nearly slip out of your grip each time. Soon her entire front is covered in a slick sheen of shiny milk, letting your hands slide easily to whatever portion you wish to fondle.");
+		output("\n\nShelly’s vocalizations have been reduced to exhausted moans, her legs loosening on your neck and dropping to rest on your shoulders");
+		if(pc.hasWings()) output(", the toes brushing your [pc.wings]");
+		output(". She attempts to grasp your head but her slippery fingers run");
+		if(pc.hasHair()) output(" through your [pc.hair]");
+		else output(" over your scalp");
+		output(" unsuccessfully. You take one of her hands as she pulls them back, giving it a reassuring squeeze.");
+		output("\n\nShe squeezes back as best as she can, grunting numbly as your nose bumps a particularly sensitive spot on her clit. You swirl your [pc.tongue] around inside her, stirring up the walls of her vagina as it tightens fitfully around you. A part of you is surprised that you haven’t gotten another egg yet, but you can’t give up now.");
+		output("\n\nWith your unoccupied hand, you slip under her butt, sliding easily under the squishy cheek with the her sugary lube paving the way. You pause when you reach the now flattened bunny tail, eliciting a yelp from it’s owner when you give it a solid tug. Her legs unconsciously open a little wider as you draw your finger in a circle around its base, tracing your thumb slowly along her flesh until you reach her asshole. You rub up and down the exposed orifice, reveling in the feeling of her plush assflesh on every side.");
+		output("\n\nAfter a few cycles, you slip your thumb into her fem-cum slicked butt. Shelly tries to vocalize her pleasure, but it comes out in a moaning half-purr as she tenses, her legs lifting herself up on your shoulders. You do your best to move the encased digit, but her heated passage constricts it too tightly to do much. You continue licking throughout the process, not giving her rest for anything.");
+		output("\n\nYou stroke the rabbit-like tail above her butt, now too soaked with juices to be fuzzy, but still feeling soft as velvet. Her moans cease completely, catching in her throat as you give the silky brush three short tugs. More for your own benefit than hers, you set your fingers in a circle, letting them feel along the entire outer edge of the fluffy ball until they meet on the other side. You reverse the direction afterwards, travelling back to the base and a few inches up her tailbone. She manages a short gasp as her fur is stroked backwards, setting her already molten thoughts into disarray.");
+		output("\n\nGradually her shock is overridden, and she sinks back to the warm, wet, cradle of the bed. Your thumb digs deeper, matching your [pc.tongue] in intensity once she no longer has the strength to stop it. A sugary haze covers your vision, and you pull away for a second to catch your breath, face dripping strands of syrupy fem-cum.");
+		output("\n\n<i>“Cum-cumming... Big egg cumming,”</i> the bunny girl manages between silent moans. It takes your hazy mind a second to remember what she’s talking about, but you duck back just in time for the bottom of a giant egg to bump you in the nose. You hear Shelly give a distressed vocalization as she pushes to no end. It would seem you’re mouth-fucking was so intense that she doesn’t have strength left to get the last egg out.");
+		
+		pc.lust(10);
+		pc.girlCumInMouth(getShellyPregContainer());
+		processTime(20);
+		clearMenu();
+		addButton(0, "Next", shellyIntenseEggLaying, 3);
+		return;
+	}
+	else if(pageNum == 3)
+	{
+		output("You assist her in the only way you can think of, by continuing said mouth-fuck. You attempt to clean the egg off the juices that coat it’s shell. Your effort are in vain, as your [pc.tongue] is coated with just as much of the sticky substance. The only recourse is to settle with suckling her clit until she cums again.");
+		output("\n\nYou dig in, rolling the sensitive bud again and again, using your fingers when your mouth tires. Shelly continues her instinctive pushing and distressing, failing each time and relaxing for a few haggard breaths before trying again. You almost think the cycle will be endless, but a lucky circumstance prevents such a loop.");
+		output("\n\nYour efforts finally pay off as she cums once again, pushing at the same time hard enough that the large egg plops out onto the saturated bed sheet. Her orgasm splatters your face with a squirt of syrup in the process. You’ve already begun to crash from the sugar rush of the original intake, and despite your best efforts to clean your face only end up smearing the sticky goo.");
+		output("\n\nYou give up after a few minutes, crawling up next to the utterly spent rabbit and snuggling into her side with a sticky kiss to her neck. Shelly seems to have fallen asleep, breathing deeply as she recovers. You join her in rest and warmth for the time being, not wanting to leave with your face covered in sugar and unsure what to do.");
+		output("\n\nThe two of you wake up a couple hours later, stuck to the bed but feeling somewhat rested. You wash off in the shower, freeing your face from the prison of crystallized sugar. When you get back you kiss the dusky girl goodbye, gathering your things and stretching before heading back to your previous endeavors. Shelly waves as you leave, smiling dreamily and rearranging the three eggs you left her with.");
+		
+		// (pass 4 hours)
+		processTime(180 + rand(45));
+		IncrementFlag("ASSISTED_SHELLY_WITH_LAYING");
+		IncrementFlag("ASSISTED_SHELLY_WITH_INTENSE_LAYING");
+		pc.girlCumInMouth(getShellyPregContainer());
+		pc.lust(5 + rand(21));
+		pc.shower();
+	}
+	clearMenu();
+	addButton(0, "Next", mainGameMenu);	
 }


### PR DESCRIPTION
### Bug/Typo Fixes
* Minor fixes.

### Updates/Edits
* Complete Ganrael codex and implement unlocks in a couple places.
* Re-implement the Goo Knight silly mode battle (it was disabled for some raisins).
* Re-implement grav-cuff button generation that was ignored during the combat revamp.
* Grav cuffs can get NPC pregnant if  applicable (female raskvel and red myr deserter).
* Vanae maiden milk can be attained through Sky Sap if character is a vaginal virgin.
* Milk Squirt tease available for very milky mams.

### New Features
* Shelly has an extra "Assist" scene, by Gardeford (accessible after Assist her laying normally 3 times or more).