### PR TITLE
Implementation of residential deck on Tavros + NPCs Aina and Fyn

### DIFF
--- a/classes/Characters/Fyn.as
+++ b/classes/Characters/Fyn.as
@@ -1,0 +1,166 @@
+package classes.Characters
+{
+	import classes.Creature;
+	import classes.GLOBAL;
+	import classes.Items.Apparel.ComfortableClothes;
+	import classes.Items.Melee.Fists;
+	
+	public class Fyn extends Creature
+	{
+		//constructor
+		public function Fyn()
+		{
+			this._latestVersion = 1;
+			this.version = this._latestVersion;
+			this._neverSerialize = false;
+			
+			this.short = "Fyn";
+			this.originalRace = "vildarii";
+			this.a = "";
+			this.capitalA = "";
+			this.long = "";
+			this.customDodge = "";
+			this.customBlock = "";
+			this.isPlural = false;
+			
+			this.meleeWeapon = new Fists();
+			this.armor = new ComfortableClothes();
+			
+			this.armor.defense = 50;
+			this.physiqueRaw = 3;
+			this.reflexesRaw = 3;
+			this.aimRaw = 3;
+			this.intelligenceRaw = 3;
+			this.willpowerRaw = 3;
+			this.libidoRaw = 30;
+			this.HPMod = 20;
+			this.shieldsRaw = 0;
+			this.HPRaw = this.HPMax();
+			this.energyRaw = 100;
+			this.lustRaw = 25;
+			
+			this.XPRaw = 50;
+			this.level = 1;
+			this.credits = 1000;
+			
+			this.inventory.push(new ComfortableClothes());
+			
+			this.typesBought[this.typesBought.length] = GLOBAL.ALL;
+			this.sellMarkup = 1.3;
+			this.buyMarkdown = .25;
+			this.keeperSell = "boop";
+			this.keeperBuy = "bop";
+			this.keeperGreeting = "BLOOP.";
+			
+			this.femininity = 20;
+			this.eyeType = GLOBAL.TYPE_FELINE;
+			this.eyeColor = "crimson";
+			this.tallness = 78;
+			this.thickness = 20;
+			this.tone = 70;
+			this.hairColor = "black";
+			this.scaleColor = "FIXME";
+			this.furColor = "FIXME";
+			this.hairLength = 10;
+			this.hairType = GLOBAL.HAIR_TYPE_REGULAR;
+			this.beardLength = 0;
+			this.beardStyle = 0;
+			this.skinType = GLOBAL.SKIN_TYPE_SKIN;
+			this.skinTone = "vermillion-red";
+			this.skinFlags = new Array(GLOBAL.FLAG_SMOOTH);
+			this.faceType = GLOBAL.TYPE_HUMAN;
+			this.faceFlags = new Array();
+			this.tongueType = GLOBAL.TYPE_HUMAN;
+			this.lipMod = 0;
+			this.earType = GLOBAL.TYPE_SYLVAN;
+			this.antennae = 0;
+			this.antennaeType = 0;
+			this.horns = 0;
+			this.hornType = 0;
+			this.armType = GLOBAL.TYPE_HUMAN;
+			this.gills = false;
+			this.wingType = 0;
+			this.legType = GLOBAL.TYPE_HUMAN;
+			this.legCount = 2;
+			this.legFlags = [GLOBAL.FLAG_PLANTIGRADE];
+			//0 - Waist
+			//1 - Middle of a long tail. Defaults to waist on bipeds.
+			//2 - Between last legs or at end of long tail.
+			//3 - On underside of a tail, used for driders and the like, maybe?
+			this.genitalSpot = 0;
+			this.tailType = 0;
+			this.tailCount = 0;
+			this.tailFlags = new Array();
+			//Used to set cunt or dick type for cunt/dick tails!
+			this.tailGenitalArg = 0;
+			//tailGenital:
+			//0 - none.
+			//1 - cock
+			//2 - vagina
+			this.tailGenital = 0;
+			//Tail venom is a 0-100 slider used for tail attacks. Recharges per hour.
+			this.tailVenom = 0;
+			//Tail recharge determines how fast venom/webs comes back per hour.
+			this.tailRecharge = 5;
+			//hipRating
+			//0 - boyish
+			//2 - slender
+			//4 - average
+			//6 - noticable/ample
+			//10 - curvy//flaring
+			//15 - child-bearing/fertile
+			//20 - inhumanly wide
+			this.hipRatingRaw = 4;
+			//buttRating
+			//0 - buttless
+			//2 - tight
+			//4 - average
+			//6 - noticable
+			//8 - large
+			//10 - jiggly
+			//13 - expansive
+			//16 - huge
+			//20 - inconceivably large/big/huge etc
+			this.buttRatingRaw = 4;
+			this.cocks = new Array();
+			this.createCock();
+			this.cocks[0].cLengthRaw = 14;
+			this.cocks[0].cThicknessRatioRaw = 0.8;
+			//balls
+			this.balls = 2;
+			this.cumMultiplierRaw = 3;
+			//Multiplicative value used for impregnation odds. 0 is infertile. Higher is better.
+			this.cumQualityRaw = 1;
+			this.cumType = GLOBAL.FLUID_TYPE_CUM;
+			this.ballSizeRaw = 3;
+			this.ballFullness = 50;
+			//How many "normal" orgams worth of jizz your balls can hold.
+			this.ballEfficiency = 15;
+			//Scales from 0 (never produce more) to infinity.
+			this.refractoryRate = 100;
+			this.minutesSinceCum = 1800;
+			this.timesCum = 1246;
+			
+			//Goo is hyper friendly!
+			this.elasticity = 1;
+			//Fertility is a % out of 100. 
+			this.fertilityRaw = 1.05;
+			this.clitLength = .5;
+			this.pregnancyMultiplierRaw = 1;
+			
+			this.breastRows[0].breastRatingRaw = 0;
+			this.nippleColor = "dark-red";
+			this.milkMultiplier = 0;
+			this.milkType = GLOBAL.FLUID_TYPE_MILK;
+			//The rate at which you produce milk. Scales from 0 to INFINITY.
+			this.milkRate = 0;
+			this.ass.wetnessRaw = 0;
+			this.ass.loosenessRaw = 1;
+			this.ass.bonusCapacity = 10;
+			this.analVirgin = true;
+			
+			this.version = _latestVersion;
+			this._isLoading = false;
+		}//end constructor
+	}//end Fyn Class
+}

--- a/classes/Creature.as
+++ b/classes/Creature.as
@@ -2427,6 +2427,7 @@ package classes {
 		public function shower():void
 		{
 			removeStatusEffect("Sweaty");
+			removeStatusEffect("Mare Musk");
 		}
 		public function canMasturbate():Boolean
 		{
@@ -3127,6 +3128,7 @@ package classes {
 			if (hasStatusEffect("Myr Venom")) currLib += Math.floor(currLib * 0.15);
 			if (accessory is Allure) currLib += 20;
 			if (hasStatusEffect("Myr Venom Withdrawal")) currLib /= 2;
+			if (hasStatusEffect("Mare Musk")) currLib += 10;
 			
 			if (currLib > libidoMax())
 			{
@@ -3431,6 +3433,7 @@ package classes {
 			}
 			//Apply sexy moves before flat boni effects
 			if (hasStatusEffect("Sexy Moves")) temp *= 1.1;
+			if (hasStatusEffect("Mare Musk")) temp += 10;
 			//Gain Sexy Thinking - gives sexiness bonus equal to (100-IQ-25)/20 + (100-WQ-25)/20
 			if(hasPerk("Sexy Thinking"))
 			{

--- a/classes/Creature.as
+++ b/classes/Creature.as
@@ -3366,6 +3366,9 @@ package classes {
 			modifiedDamage.add(accessory.baseDamage);
 			modifiedDamage.add(shield.baseDamage);
 			
+			//Add bonus to both melee and ranged attacks
+			if (hasStatusEffect("Lightning Moves")) modifiedDamage.multiply(1.1);
+			
 			return modifiedDamage;
 		}
 		public function defense(): Number 
@@ -3426,6 +3429,8 @@ package classes {
 				if(hasFur()) temp -= statusEffectv1("Sweaty") * 5;
 				temp -= statusEffectv1("Sweaty") * 5;
 			}
+			//Apply sexy moves before flat boni effects
+			if (hasStatusEffect("Sexy Moves")) temp *= 1.1;
 			//Gain Sexy Thinking - gives sexiness bonus equal to (100-IQ-25)/20 + (100-WQ-25)/20
 			if(hasPerk("Sexy Thinking"))
 			{
@@ -3457,6 +3462,8 @@ package classes {
 			if (hasPerk("Improved Agility")) {
 				temp += 10;
 			}
+			//Apply sexy moves before flat boni effects
+			if (hasStatusEffect("Sexy Moves")) temp *= 1.1;
 			if (hasStatusEffect("Riposting"))
 			{
 				temp += 15;

--- a/classes/TiTS.as
+++ b/classes/TiTS.as
@@ -148,6 +148,8 @@
 		include "../includes/tavros/shearBeauty.as";
 		include "../includes/tavros/shelly.as";
 		include "../includes/tavros/vahn.as";
+		include "../includes/tavros/aina.as";
+		include "../includes/tavros/fyn.as";
 		
 		//First planet
 		include "../includes/mhenga/burt.as";

--- a/includes/CodexEntries.as
+++ b/includes/CodexEntries.as
@@ -38,6 +38,7 @@ public function configureCodex():void
 	CodexManager.addCodexEntry(CodexManager.CODEX_TYPE_RACE, "Core Worlds", "Thraggen", thraggenCodexEntry,true);
 	CodexManager.addCodexEntry(CodexManager.CODEX_TYPE_RACE, "Core Worlds", "Varmints", varmintCodex);
 	CodexManager.addCodexEntry(CodexManager.CODEX_TYPE_RACE, "Core Worlds", "Gryvain", gryvainCodexEntry, true);
+	CodexManager.addCodexEntry(CodexManager.CODEX_TYPE_RACE, "Core Worlds", "Vildarii", vildariiCodexEntry);
 	
 	CodexManager.addCodexEntry(CodexManager.CODEX_TYPE_RACE_MHENGA, "Mhen'ga", "Cunt Snakes", cuntSnakeCodexEntry);
 	CodexManager.addCodexEntry(CodexManager.CODEX_TYPE_RACE_MHENGA, "Mhen'ga", "Kerokoras",kerokorasCodexEntry);
@@ -672,6 +673,39 @@ public function thraggenCodexEntry():void
 	outputCodex("\n\n");
 	CodexManager.viewedEntry("Thraggen");
 }
+public function vildariiCodexEntry():void 
+{
+	clearOutputCodex();
+	showBust("9999");
+	outputCodex(header("Vildarii"));
+	outputCodex("<b>Name (Singular & Plural):</b> Vildarii");
+	outputCodex("\n<b>Pronunciation:</b> 'Vil-dahr-ee'");
+	outputCodex("\n<b>Sexes:</b> Male, Female");
+	outputCodex("\n<b>Height:</b> From five to six feet, with rare exceptions on either side of the spectrum.");
+	outputCodex("\n<b>Weight:</b> Between 60 to 85 kilograms, with males generally being 10 kilograms heavier than females on average.");
+	outputCodex("\n<b>Average Lifespan:</b> Vildarii have a natural lifespan of up to two centuries. Scientists believe this longevity is directly related to their inherently morphic biology.");
+	outputCodex("\n\n");
+	outputCodex(blockHeader("Appearance"));
+	outputCodex("Vildarii are one of a handful of polymorphic races currently integrated into the UGC. As humanoid shapeshifters, they are able to take other humanoid forms, so long as these new forms do not deviate excessively from their natural, 'true' form. As such, it can be quite hard to identify a vildarii from appearance alone, unless they are assuming this form.\n\nWhile many polymorphic races have natural forms that lack distinct protrusions and sexual characteristics, vildarii are not one of them, possessing a natural form that is not too different that from a terran human. Still, there are distinct physical characteristics that set them apart; every single vildarii has vermillion-red skin, jet black hair, and large pointed ears, typically five inches in length. Many races describe vidariii ears as being distinctly 'elf-like'.\n\nBy far the most distinctive physical characteristic of the race is their cat-like eyes; while their sclera is white, their irises are a fiery-crimson with black slits.");
+	outputCodex("\n\n");
+	outputCodex(blockHeader("Polymorphism"));
+	outputCodex("Sitting somewhere in the center of polymorphic ability, vildarii are all born with this trait, but not all are equal in its application. Like any physical activity, there are those who work and train at polymorphism, honing this art to a higher standard than others. While all vildarii take part in classes to train this trait as part of average schooling, the average member of the species can usually change their physical coloration and eyes, but nothing else. Those who continue to study and train this ability can make further, more extreme changes.\n\nThe more a physical alteration deviates from one's natural state, the more of a toll it takes on the body. Most vildarii cannot perpetually assume an alternate form for more than a day without at the very least one hour-long break. On top of this, the act of polymorphism—particularly the initial transformation—consumes a massive amount of bodily nutrients, particularly fats, sugars, and protein. For those who transform regularly, these must be replenished each and every time. It is not unusual to see vildarii binge-eating certain foods, while still appearing physically fit.");
+	outputCodex("\n\n");
+	outputCodex(blockHeader("Typical Environments"));
+	outputCodex("Vildarii have been part of the UGC for several rushes, and benefited from not being the first polymorphic race to join, completely avoiding the fears and prejudices leveled against earlier species. After their genetic sequence was mapped into scanning devices, they incorporated themselves with ease into galactic society, since becoming as readily accepted as races such as the Ausar and Kaithrit.\n\nThe species can be found on almost any planet, blending in both physically and culturally. Vildarii are naturally morphic in both mind and body, loving to immerse themselves in other cultures and absorb all there is to offer.");
+	outputCodex("\n\n");
+	outputCodex(blockHeader("Society"));
+	outputCodex("Vildarii are generally considered hedonists; travelling to distant stars just to relish in local cuisines, arts, and above all, sensual pleasures there is to offer. The galaxy is generally considered a sampling plate, and with their long life-spans, they have plenty of time to taste-test it all. It is perhaps not surprising in that light that the species is a wholehearted advocate of the UGC's Rush program. Some vildarii will even join non-integrated species in secret; making themselves look like a local member to indulge in their lifestyle, unhindered by alien prejudice.\n\nMost vildarii spend a great deal of time trying to be as physically and socially amicable as possible. Many vildari get genetic splicing done to this effect, particularly getting potent pheromone glands to maximize their appeal.\n\nThe most common career paths for a vildarii are diplomacy, social sciences, performing arts, modelling, and prostitution.");
+	outputCodex("\n\n");
+	outputCodex(blockHeader("Reproduction and Sex"));
+	outputCodex("While vildarii are polymorphic, their reproductive biology is rather straightforward and similar to terran humans. They have males and females carrying sperm and ova respectively. Through intercourse, sperm is delivered to the ova, fertilizing it and forming an embryo. Pregnancy usually lasts six months, resulting in the birth of a child, or more rarely, twins.\n\nThere is one significant difference between vildarii sperm and ova, and that of humans. While humans can only successfully produce offspring with a select number of species, vildarii are able to breed with nearly any known species. This is a result of both their ability to shift the arrangement of their sexual organs, and the naturally adaptive nature of their sperm and ova. For example, while humans and most other species cannot produce offspring with a leithan, this is not an obstacle for a vildarii, whose sperm and ova would adapt to couple with the selective species.\n\nMost matings with other species results in a half-vildarii; a native with with the skin coloration, hair, and limited morphic properties of a vildarii.");
+	outputCodex("\n\n");
+	outputCodex(blockHeader("Religion"));
+	outputCodex("Vildarii have a native religious order called 'Followers of the Infinite Aspect'. They believe a single entity exists that represents all things, able to take the face and empathise with every species and being in the universe. They believe being able to comprehend such a being is nigh-impossible, but adherents strive to emulate the Infinite Aspect by living their lives in other people's shoes and trying to see the universe from as many aspects as possible.");
+	
+	CodexManager.viewedEntry("Vildarii");
+}
+
 public function varmintCodex():void
 {
 	clearOutputCodex();

--- a/includes/game.as
+++ b/includes/game.as
@@ -1207,6 +1207,23 @@ public function statusTick():void {
 
 public function variableRoomUpdateCheck():void
 {
+	/* TAVROS STATION */
+	
+	//Residental Deck
+	//Place Aina's NPC flag depending whenever or not the PC meet her + generate her room
+	if(flags["HELPED_AINA"] == undefined) 
+	{ 
+		rooms["RESIDENTIAL DECK 15"].addFlag(GLOBAL.NPC);
+	}
+	else if(flags["HELPED_AINA"] == true) 
+	{ 
+		rooms["RESIDENTIAL DECK 15"].removeFlag(GLOBAL.NPC);
+		unlockAinasRoom();
+	} else {
+		rooms["RESIDENTIAL DECK 15"].removeFlag(GLOBAL.NPC);
+		lockAinasRoom();
+	}
+	
 	/* MHENGA */
 	
 	//Kelly's work - close/open Xenogen Biotech.

--- a/includes/roomFunctions.as
+++ b/includes/roomFunctions.as
@@ -106,10 +106,15 @@ public function hangarBonus():Boolean
 	if(currentLocation == "LIFT: MERCHANT DECK") {
 		output("\n\n<b>You are currently on the merchant deck.</b>");
 		addButton(7,"Down",liftMove, "TAVROS LIFT");
+		addButton(5,"Up",liftMove, "LIFT: RESIDENTIAL DECK");
 	}
 	else if(currentLocation == "TAVROS LIFT") {
 		output("\n\n<b>You are currently on the hangar deck.</b>");
 		addButton(5,"Up",liftMove, "LIFT: MERCHANT DECK");
+	} 
+	else if(currentLocation == "LIFT: RESIDENTIAL DECK") {
+		output("\n\n<b>You are currently on the residential deck.</b>");
+		addButton(7,"Down",liftMove, "LIFT: MERCHANT DECK");
 	}
 	return false;
 }
@@ -1023,4 +1028,29 @@ public function fixCommsOnTarkus():void
 	processTime(1);
 	clearMenu();
 	addButton(0,"Next",mainGameMenu);
+}
+
+//adds a Button for the Notice Board on the residential deck on Tavros
+public function tavrosResidentialDeckNoticeBoard():void {
+	addButton(0,"NoticeBoard",displayNoticeBoardRD);
+}
+
+public function displayNoticeBoardRD():void {
+	clearOutput();
+	
+	output("While this public notice board is holographic, it's easy to bring up a digipen and scribble whatever you want on it. There's a section for official notices to deck residents, informing them of maintenance schedules and other important events. The rest is for use by the public; filled with general requests or advertisements.");
+	
+	if(flags["AINA_NOTICE_1_READ"] == undefined) output("\n\n<b>New:</b>");
+	else output("\n\nSeen before:");
+	output(" It appears someone in the western walkway, room 154, is looking for a 'discreet individual' to help them with an unspecified problem. Pretty ambiguous.");
+	
+	if(flags["FYN_NOTICE_1_READ"] == undefined) output("\n\n<b>New:</b>");
+	else output("\n\nSeen before:");
+	output(" There's a notice for 'interested individuals' to visit the eastern walkway for 'lessons', room 112. There seems to have been more to the message, but someone else has placed their own holo notice over it.");
+
+	flags["AINA_NOTICE_1_READ"] = true;
+	flags["FYN_NOTICE_1_READ"] = true;
+	
+	clearMenu();
+	addButton(0,"Back",mainGameMenu);
 }

--- a/includes/rooms.as
+++ b/includes/rooms.as
@@ -200,7 +200,7 @@ public function initializeRooms():void
 	//104 "LIFT: MERCHANT DECK". In The Lift - Merchant's Thoroughfare
 	rooms["LIFT: MERCHANT DECK"] = new RoomClass(this);
 	rooms["LIFT: MERCHANT DECK"].roomName = "LIFT: MERCHANT\nDECK";
-	rooms["LIFT: MERCHANT DECK"].description = "Steady, mechanical thrums suffuse the stuffy air inside this tube of metal and plastic. There is a brass-hued railing to stablize oneself with during the highspeed travel through the kilometers-long station and a sturdy mechanical keypad with which to designate your target level. Much of the lift stations look to be inactive; right now, the hangar and the merchant's thoroughfare are the only areas reachable by lift.";
+	rooms["LIFT: MERCHANT DECK"].description = "You're within a stuffy tube of metal and plastic. Steady, mechanical thrums suffuse the air around you. The inside of the cylinder-like lift is lined by a brass-hued railing, used to steady oneself during high speed travel through the kilometers-long station.\n\nThere's a sturdy mechanical keypad with which to designate your target level. Right now, the only floors of interest are the hangar, and the merchant and residential levels.";
 	rooms["LIFT: MERCHANT DECK"].planet = "TAVROS STATION";
 	rooms["LIFT: MERCHANT DECK"].system = "SYSTEM: KALAS";
 	rooms["LIFT: MERCHANT DECK"].eastExit = "MERCHANT'S THOROUGHFARE2";
@@ -228,7 +228,7 @@ public function initializeRooms():void
 	//106"TAVROS LIFT". In The Lift - The Hangar
 	rooms["TAVROS LIFT"] = new RoomClass(this);
 	rooms["TAVROS LIFT"].roomName = "LIFT: HANGAR\nDECK";
-	rooms["TAVROS LIFT"].description = "Steady, mechanical thrums suffuse the stuffy air inside this tube of metal and plastic. There is a brass-hued railing to stablize oneself with during the highspeed travel through the kilometers-long station and a sturdy mechanical keypad with which to designate your target level. Much of the lift stations look to be inactive; right now, the hangar and the merchant's thoroughfare are the only areas reachable by lift.";
+	rooms["TAVROS LIFT"].description = "You're within a stuffy tube of metal and plastic. Steady, mechanical thrums suffuse the air around you. The inside of the cylinder-like lift is lined by a brass-hued railing, used to steady oneself during high speed travel through the kilometers-long station.\n\nThere's a sturdy mechanical keypad with which to designate your target level. Right now, the only floors of interest are the hangar, and the merchant and residential levels.";
 	rooms["TAVROS LIFT"].planet = "TAVROS STATION";
 	rooms["TAVROS LIFT"].system = "SYSTEM: KALAS";
 	rooms["TAVROS LIFT"].eastExit = "TAVROS HANGAR";
@@ -534,6 +534,267 @@ public function initializeRooms():void
 	rooms["INESSA"].addFlag(GLOBAL.PUBLIC);
 	rooms["INESSA"].addFlag(GLOBAL.COMMERCE);
 	rooms["INESSA"].runOnEnter = happyTailsBonus;
+	
+	
+	//=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
+	//=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
+	//				TAVROS RESIDENTIAL DECK
+	//=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
+	//=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
+	
+	//1001 Lift RESIDENTIAL Deck (Technically Deck 1 in the Docs)
+	rooms["LIFT: RESIDENTIAL DECK"] = new RoomClass(this);
+	rooms["LIFT: RESIDENTIAL DECK"].roomName = "LIFT:\nRESIDENTIAL DECK";
+	rooms["LIFT: RESIDENTIAL DECK"].description = "You're within a stuffy tube of metal and plastic. Steady, mechanical thrums suffuse the air around you. The inside of the cylinder-like lift is lined by a brass-hued railing, used to steady oneself during high speed travel through the kilometers-long station.\n\nThere's a sturdy mechanical keypad with which to designate your target level. Right now, the only floors of interest are the hangar, and the merchant and residential levels.";
+	rooms["LIFT: RESIDENTIAL DECK"].planet = "TAVROS STATION";
+	rooms["LIFT: RESIDENTIAL DECK"].system = "SYSTEM: KALAS";
+	rooms["LIFT: RESIDENTIAL DECK"].northExit = "RESIDENTIAL DECK 6";
+	rooms["LIFT: RESIDENTIAL DECK"].southExit = "RESIDENTIAL DECK 2";
+	rooms["LIFT: RESIDENTIAL DECK"].westExit = "";
+	rooms["LIFT: RESIDENTIAL DECK"].eastExit = "";
+	rooms["LIFT: RESIDENTIAL DECK"].moveMinutes = 1;
+	rooms["LIFT: RESIDENTIAL DECK"].addFlag(GLOBAL.INDOOR);
+	rooms["LIFT: RESIDENTIAL DECK"].addFlag(GLOBAL.LIFTDOWN);
+	rooms["LIFT: RESIDENTIAL DECK"].addFlag(GLOBAL.PUBLIC);
+	rooms["LIFT: RESIDENTIAL DECK"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	rooms["LIFT: RESIDENTIAL DECK"].runOnEnter = hangarBonus;
+	
+	//1002 South Plaza
+	rooms["RESIDENTIAL DECK 2"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 2"].roomName = "SOUTH PLAZA";
+	rooms["RESIDENTIAL DECK 2"].description = "You're in front of a row of elevator shafts surrounded by a large plaza area. The design reminds you of a city square, but instead of a fountain feature, the lifts are the centerpiece. Still, there's all the common fare of a common space; there are decorative garden beds with exotic yet harmless shrubbery and park benches to sit on.\n\nBeyond the sprawling public space and in each of the four cardinal directions are residential arcades; high-roofed walkways marked by countless successive arches.\n\nA holographic board floats here, littered with community notices for deck residents. It seems anyone can put a message here, and quite a few people have taken advantage of it.";
+	rooms["RESIDENTIAL DECK 2"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 2"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 2"].northExit = "LIFT: RESIDENTIAL DECK";
+	rooms["RESIDENTIAL DECK 2"].southExit = "RESIDENTIAL DECK 16";
+	rooms["RESIDENTIAL DECK 2"].westExit = "RESIDENTIAL DECK 9";
+	rooms["RESIDENTIAL DECK 2"].eastExit = "RESIDENTIAL DECK 3";
+	rooms["RESIDENTIAL DECK 2"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 2"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 2"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 2"].addFlag(GLOBAL.OBJECTIVE);
+	rooms["RESIDENTIAL DECK 2"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	rooms["RESIDENTIAL DECK 2"].runOnEnter = tavrosResidentialDeckNoticeBoard;
+	
+	//1003 South-East Plaza
+	rooms["RESIDENTIAL DECK 3"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 3"].roomName = "SOUTH-EAST\nPLAZA";
+	rooms["RESIDENTIAL DECK 3"].description = "This corner of the residential plaza is quite busy. The foot traffic is between the large elevator shafts in the center of the plaza and people's dwellings. There are apartments lining the plaza, a premium spot for anyone in a rush.\n\nThere are some large trees here casting shade upon the paved ground. The only breeze is from the deck's air conditioning systems, which keep everything at a nice, mild temperature.\n\nYou can follow the curve of the plaza here northward, towards the bridge to the western ward. You can also head west where the entrance to the deck's elevators are.";
+	rooms["RESIDENTIAL DECK 3"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 3"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 3"].northExit = "RESIDENTIAL DECK 4";
+	rooms["RESIDENTIAL DECK 3"].westExit = "RESIDENTIAL DECK 2";
+	rooms["RESIDENTIAL DECK 3"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 3"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 3"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 3"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	
+	//1004 East Plaza
+	rooms["RESIDENTIAL DECK 4"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 4"].roomName = "EAST PLAZA";
+	rooms["RESIDENTIAL DECK 4"].description = "There's a large lush patch of purple plants here in the plaza. They're covered in patchy blue spots. Soft, cyan blossoms are poking out from them on long, dangly stems. They smell fresh and crisp rather than floral.\n\nThe plaza stretches out north to south, but there's a large residential arcade to the east. It seems to head all the way out to a residential ward, though the thoroughfare itself is lined with doors to residential apartments.";
+	rooms["RESIDENTIAL DECK 4"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 4"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 4"].northExit = "RESIDENTIAL DECK 5";
+	rooms["RESIDENTIAL DECK 4"].southExit = "RESIDENTIAL DECK 3";
+	rooms["RESIDENTIAL DECK 4"].eastExit = "RESIDENTIAL DECK 10";
+	rooms["RESIDENTIAL DECK 4"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 4"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 4"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 4"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	
+	//1005 North-East Plaza
+	rooms["RESIDENTIAL DECK 5"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 5"].roomName = "NORTH-EAST\nPLAZA";
+	rooms["RESIDENTIAL DECK 5"].description = "This part of the plaza is marked by large, leafy ferns, and by their distinctly green look, they're likely terran. Some station tourists are stopping to take photos; they must be authentic palm trees. They lack coconuts, either through rigorous pruning or selective breeding, making it safe for pedestrians to pass beneath.\n\nThe plaza continues east and south in a wide curve.";
+	rooms["RESIDENTIAL DECK 5"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 5"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 5"].southExit = "RESIDENTIAL DECK 4";
+	rooms["RESIDENTIAL DECK 5"].westExit = "RESIDENTIAL DECK 6";
+	rooms["RESIDENTIAL DECK 5"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 5"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 5"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 5"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	
+	//1006 North Plaza
+	rooms["RESIDENTIAL DECK 6"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 6"].roomName = "NORTH PLAZA";
+	rooms["RESIDENTIAL DECK 6"].description = "You're standing on the north side of the plaza and in front of a large row of elevator shafts. All around you is a massive public plaza, filled with scenic shrubbery and paved walkways. There's a few park benches as well, which residents seem to be making full use of.\n\nAt each of the cardinal points are gigantic residential arcades that continue out as far as the eye can see. Just like the walls of the plaza, the arcades are lined with residential entrances. It must be nice to walk right out your door and into such a nice garden-filled space.\n\nYou can head in any direction, with south heading back into the elevators and north heading into one of the residential thoroughfares. East and west heads around the plaza.";
+	rooms["RESIDENTIAL DECK 6"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 6"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 6"].northExit = "RESIDENTIAL DECK 12";
+	rooms["RESIDENTIAL DECK 6"].southExit = "LIFT: RESIDENTIAL DECK";
+	rooms["RESIDENTIAL DECK 6"].westExit = "RESIDENTIAL DECK 7";
+	rooms["RESIDENTIAL DECK 6"].eastExit = "RESIDENTIAL DECK 5";
+	rooms["RESIDENTIAL DECK 6"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 6"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 6"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 6"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	
+	//1007 North-West Plaza
+	rooms["RESIDENTIAL DECK 7"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 7"].roomName = "NORTH-WEST\nPLAZA";
+	rooms["RESIDENTIAL DECK 7"].description = "It's hard not to be dazzled by this portion of the plaza. Between the walkways are clusters of prismatic crystals, ranging in size from tiny gem-like shrubs to twenty-foot monoliths. Artificial light flows from above, striking the stones and causing them to sparkle.\n\nA few water features run over the crystals, causing their scintillating light to flurry about beneath the ripples. It's almost hypnotic, but very relaxing. Understandably, there's a lot of public seating about.\n\nThe plaza curves here from west to south, lined by various residential apartments.";
+	rooms["RESIDENTIAL DECK 7"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 7"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 7"].southExit = "RESIDENTIAL DECK 8";
+	rooms["RESIDENTIAL DECK 7"].eastExit = "RESIDENTIAL DECK 6";
+	rooms["RESIDENTIAL DECK 7"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 7"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 7"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 7"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	
+	//1008 West Plaza
+	rooms["RESIDENTIAL DECK 8"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 8"].roomName = "WEST PLAZA";
+	rooms["RESIDENTIAL DECK 8"].description = "This part of the plaza is filled with shielded aviaries housing all kinds of colorful winged creatures. When they're not hovering about, they're resting in their nests, most of which are built in hollowed out trees. A rainbow-hued, six-winged bird seems to have pride of place at the top of the largest tree.\n\nThere's a large arcade-like thoroughfare to the west, stretching out all the way to a far off residential ward. Identical to the plaza, the side-walls are lined with residential entryways, each decorated as the owner sees fit.\n\nBesides the west walkway, you can head north or south here and circle around the plaza. This side doesn't seem to have an entry point to the elevators.";
+	rooms["RESIDENTIAL DECK 8"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 8"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 8"].northExit = "RESIDENTIAL DECK 7";
+	rooms["RESIDENTIAL DECK 8"].southExit = "RESIDENTIAL DECK 9";
+	rooms["RESIDENTIAL DECK 8"].westExit = "RESIDENTIAL DECK 14";
+	rooms["RESIDENTIAL DECK 8"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 8"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 8"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 8"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+
+	//1009 South-West Plaza
+	rooms["RESIDENTIAL DECK 9"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 9"].roomName = "SOUTH-WEST\nPLAZA";
+	rooms["RESIDENTIAL DECK 9"].description = "This area has a lot of strange interpretive art. There are a number of residents dwelling near them, each arguing about what exactly the messy-looking statues are. It's like an inkblot test; everyone seems to see something a little different.\n\nThe plaza curves around here from north to west. The latter leads to the front of the deck's elevators.";
+	rooms["RESIDENTIAL DECK 9"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 9"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 9"].northExit = "RESIDENTIAL DECK 8";
+	rooms["RESIDENTIAL DECK 9"].eastExit = "RESIDENTIAL DECK 2";
+	rooms["RESIDENTIAL DECK 9"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 9"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 9"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 9"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+
+	//1010 East Walkway 1
+	rooms["RESIDENTIAL DECK 10"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 10"].roomName = "EAST\nWALKWAY";
+	rooms["RESIDENTIAL DECK 10"].description = "The eastern thoroughfare is massive and multi-laned, with some residents opting to take small hover-carts between the plaza elevators and the outer wards. Thankfully, the small yet speedy vehicles don't share the same routes as the pedestrians, only scooting along the inner lanes.\n\nThere are many residential estates located in the plaza, some with vehicles parked out front and console locked.\n\nYou can head east and follow the long walkway, or west and to the central plaza.";
+	rooms["RESIDENTIAL DECK 10"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 10"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 10"].westExit = "RESIDENTIAL DECK 4";
+	rooms["RESIDENTIAL DECK 10"].eastExit = "RESIDENTIAL DECK 11";
+	rooms["RESIDENTIAL DECK 10"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 10"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 10"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 10"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	
+	//1011 East Walkway 2
+	rooms["RESIDENTIAL DECK 11"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 11"].roomName = "EAST\nWALKWAY";
+	rooms["RESIDENTIAL DECK 11"].description = "There are a number of double story apartments here with balconies, easily fitting into the high-roofed residential arcade. There's also a dock for hover carts and a small payment terminal, for those not wishing to walk back and forth down the thoroughfare.\n\nThere's a particularly large apartment to the north of here. The classy pillars and archways mix with the lascivious color scheme of red and gold, making it look like an upper-class bordello more than a residence. The holo-sign next to the door reads 112.\n\nThere's a large steel wall to the east. West leads back in the direction of the central plaza.";
+	rooms["RESIDENTIAL DECK 11"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 11"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 11"].northExit = "RESIDENTIAL DECK 19";
+	rooms["RESIDENTIAL DECK 11"].westExit = "RESIDENTIAL DECK 10";
+	rooms["RESIDENTIAL DECK 11"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 11"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 11"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 11"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	
+	//1012 North Walkway 1
+	rooms["RESIDENTIAL DECK 12"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 12"].roomName = "NORTH\nWALKWAY";
+	rooms["RESIDENTIAL DECK 12"].description = "The northward walkway is huge both longways and upward, making it easier for larger species to get about. Hover-carts are for rent here, allowing easy travel around the residential deck. You notice some of them have different steering wheels and seating, allowing for all sorts of species to make use of them.\n\nThe residential buildings lining this part of the deck aren't very decorated, and those that are have been done with cheap holos. You can easily see through the flickering facades, making such holo-decor all but pointless.\n\nTo the north, the walkway continues for quite some time. The central plaza lies to the south, along with the elevators that allow deck transit.";
+	rooms["RESIDENTIAL DECK 12"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 12"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 12"].northExit = "RESIDENTIAL DECK 13";
+	rooms["RESIDENTIAL DECK 12"].southExit = "RESIDENTIAL DECK 6";
+	rooms["RESIDENTIAL DECK 12"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 12"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 12"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 12"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	
+	//1013 North Walkway 2
+	rooms["RESIDENTIAL DECK 13"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 13"].roomName = "NORTH\nWALKWAY";
+	rooms["RESIDENTIAL DECK 13"].description = "This largely unlived in part of the deck is almost achingly quiet, each footstep echoing down the incredibly tall and long walkway. Each room has ridiculously cheap pricing on it. There are also a few advertising boards up, mostly displaying the latest movies and soft-drink products.\n\nSouth leads towards the central plaza. There's a large steel wall to the north. It seems that part of the station is still under construction.";
+	rooms["RESIDENTIAL DECK 13"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 13"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 13"].southExit = "RESIDENTIAL DECK 12";
+	rooms["RESIDENTIAL DECK 13"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 13"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 13"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 13"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	
+	//1014 West Walkway 1
+	rooms["RESIDENTIAL DECK 14"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 14"].roomName = "WEST\nWALKWAY";
+	rooms["RESIDENTIAL DECK 14"].description = "The western walkway has a lot of glitzy looking apartments. It's only a <i>very</i> close look and touch that reveals they're all covered in hard-light holos, not designed out of gold and marble. By the look of the few who haven't 'covered up', they're actually exceptionally plain; probably why their owners invested in the hard-light flourish. The walkway continues west for quite a while. It's a considerably shorter walk back east and to the deck's public plaza.";
+	rooms["RESIDENTIAL DECK 14"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 14"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 14"].westExit = "RESIDENTIAL DECK 15";
+	rooms["RESIDENTIAL DECK 14"].eastExit = "RESIDENTIAL DECK 8";
+	rooms["RESIDENTIAL DECK 14"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 14"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 14"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 14"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	
+	//1015 West Walkway 2
+	rooms["RESIDENTIAL DECK 15"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 15"].roomName = "WEST\nWALKWAY";
+	rooms["RESIDENTIAL DECK 15"].description = "This part of the walkway is fairly standard. There's a few humble decorations outside the stock-standard doors: pot plants, mats, the usual fare. Even in space and during such an advanced technological era, some things don't change all that much.\n\nTo the south, you notice a residence with two barn-like doors. Attached to the artificial windows are boxes filled with blossoming flowers. The number beside the door is 154.\n\nThe thoroughfare here ends in a gigantic steel wall to the west. Seems that part of the station is still under construction. You can only head back east.";
+	rooms["RESIDENTIAL DECK 15"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 15"].system = "SYSTEM: KALAS";
+	//rooms["RESIDENTIAL DECK 15"].southExit = "RESIDENTIAL DECK 18"; -> added to game.as
+	rooms["RESIDENTIAL DECK 15"].eastExit = "RESIDENTIAL DECK 14";
+	rooms["RESIDENTIAL DECK 15"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 15"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 15"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 15"].addFlag(GLOBAL.NPC);
+	rooms["RESIDENTIAL DECK 15"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	rooms["RESIDENTIAL DECK 15"].runOnEnter = checkIfAinaIsAround;
+	
+	//1016 South Walkway 1
+	rooms["RESIDENTIAL DECK 16"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 16"].roomName = "SOUTH\nWALKWAY";
+	rooms["RESIDENTIAL DECK 16"].description = "The considerably large southern arcade stretches out as far as the eye can see, but many of the residences are for sale. By the looks of things, they're unlived in, which means this part of the deck must be brand new. Given the Rush started not long ago, it's not surprising—galactic expansion <i>is</i> the name of the game right now. You can head south and along the walkway, or north and towards the public plaza.";
+	rooms["RESIDENTIAL DECK 16"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 16"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 16"].northExit = "RESIDENTIAL DECK 2";
+	rooms["RESIDENTIAL DECK 16"].southExit = "RESIDENTIAL DECK 17";
+	rooms["RESIDENTIAL DECK 16"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 16"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 16"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 16"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+	
+	//1017 South Walkway 2
+	rooms["RESIDENTIAL DECK 17"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 17"].roomName = "SOUTH\nWALKWAY";
+	rooms["RESIDENTIAL DECK 17"].description = "This part of the thoroughfare shines with countless holo-decorated apartments. The light-projected exteriors spruce up the otherwise plain exteriors, transforming this region into a shimmering cultural hotpot. One of the apartments to the west doesn't have a virtual exterior, but it <i>does</i> have a rather pimped-out looking hoverbike. Black, sleek looking plates cover its outside, with constantly shifting flame-paint on the sides; must be digital. Looks like a two-seater.\n\nA fair way north is the central plaza and the deck elevators. There's a large steel wall to the south with 'under construction' written on it.";
+	rooms["RESIDENTIAL DECK 17"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 17"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 17"].northExit = "RESIDENTIAL DECK 16";
+	rooms["RESIDENTIAL DECK 17"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 17"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 17"].addFlag(GLOBAL.PUBLIC);
+	rooms["RESIDENTIAL DECK 17"].addFlag(GLOBAL.NUDITY_ILLEGAL);
+
+	//1018 Aina's Apartment
+	//Added in variableRoomUpdateCheck() in game.as since the room is only available 
+	//if the PC helped Aina - and adding it in her code was not enough as it persisted
+	//onload for other characters.
+
+	//1019 Fyn's Apartment
+	rooms["RESIDENTIAL DECK 19"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 19"].roomName = "FYN'S\nAPARTMENT";
+	rooms["RESIDENTIAL DECK 19"].description = "This incredibly large apartment must have cost a small fortune of credits to buy, far and above the normal fare in Tavros station. The polished synth-oak floors look indistinguishable from the real thing, giving the whole place a glamorous air. The common area is huge, filled with a circular island-like kitchen and seating around the outskirts. It's the sort of place where many people can visit quite easily. There's an open doorway leading to a lush looking bedroom with silky sheets and a king sized bed. The bedhead has silk ropes around it... whatever could <i>they</i> be for? Another room seems to lead to a dance studio.";
+	rooms["RESIDENTIAL DECK 19"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 19"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 19"].southExit = "RESIDENTIAL DECK 11";
+	rooms["RESIDENTIAL DECK 19"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 19"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 19"].addFlag(GLOBAL.PRIVATE);
+	rooms["RESIDENTIAL DECK 19"].addFlag(GLOBAL.NPC);
+	rooms["RESIDENTIAL DECK 19"].runOnEnter = checkFynDoorScene;
+	
+	//END RESIDENTIAL DECK
+	
 
 	//0. Ship Hanger
 	rooms["SHIP HANGAR"] = new RoomClass(this);

--- a/includes/tavros/aina.as
+++ b/includes/tavros/aina.as
@@ -9,6 +9,7 @@
 //AINA_TALKED_ABOUT_HERSELF:	If the player asked Aina about herself in the past (true or undefined)
 //AINA_TALKED_ABOUT_TOYS:		If the player asked Aina about her sextoys (true or undefined)
 //AINA_SEXED_WITH_TOY:			If the player did her Anal&Wand scene in the past (true or undefined)
+//AINA_SHOWER_USED:				If the player used the shower in Aina's apartment (true or undefined)
 
 
 //Heat mechanics: 
@@ -311,6 +312,10 @@ public function ainaIsVirgin():Boolean {
 public function ainaSexed(times:int):void {
 	if(flags["AINA_SEXED"] == undefined) flags["AINA_SEXED"] = 0;
 	flags["AINA_SEXED"] += times;
+	
+	//currently applies to all sex scenes, but since this may not be the case in the future,
+	//the effect is kept as a seperate function
+	applyAinaMareMuskEffect();
 }
 
 //render Button for meeting Aina in her apartment on the residential deck(#18)
@@ -351,9 +356,10 @@ public function ainaMenu():void
 	addButton(0, "Appearance", ainaAppearance);
 	if(!ainaIsInHeat()) addButton(1, "Talk", ainaTalk);
 	else addDisabledButton(1, "Talk", "Talk", "Aina must not be in heat to talk to her.");
-	//addDisabledButton(2, "Tea", "Tea", "Aina must not be in heat to enjoy a cup of tea."); //Listed in DOC but no text was supplied for it
 	addButton(2, "OfferSex", ainaSexMenu);
-	addButton(3,"Leave",mainGameMenu);
+	addButton(3, "Shower", ainaShower);
+	
+	addButton(14,"Leave",mainGameMenu);
 }
 
 public function ainaAppearance():void
@@ -524,9 +530,23 @@ public function ainaTalksAboutSexToys():void
 	ainaTalkNavigation(ainaTalksAboutSexToys);
 }
 
-public function ainaTea():void
+public function ainaShower():void
 {
-	//No text provided in DOC
+	if (flags["AINA_SHOWER_USED"] == undefined) output("You ask Aina if you can use her shower, and she nods enthusiastically.\n\n“Sure! Just on the right.”");
+	
+	output("You hop into the centauress' impressively large shower to clean yourself off. Rivulets of water run down your [pc.skinFurScales]. You rub soap all over your body and then clean it off, leaving you perfectly spotless.");
+	output("\n\nHopping out, you let out a happy sigh, rubbing a towel over your [pc.hair]. You're feeling refreshed in so many ways!");
+	output("\n\n<b>You are now clean!</b>");
+	
+	processTime(10 + rand(5));
+	
+	pc.shower();
+	addButton(14, "Back", ainaMenu);
+}
+
+public function applyAinaMareMuskEffect():void 
+{
+	pc.createStatusEffect("Mare Musk",0,0,0,0,false,"Icon_Smelly","You smell like a horny mare! The potent female scent is sure to drive others wild—though it gets you a little worked up as well.",false,0);
 }
 
 public function ainaSexMenu():void
@@ -652,9 +672,7 @@ public function ainaSexedFromBehind():void
 	else
 	{
 	output("\n\n“That was amazing... just like last time...” Aina blushes, absentmindedly tucking a messed-up lock behind her ear. “Um, you know, if you're ever in Res Deck again, feel free to call around. I always love having you over... whether we're talking or, you know, doing other things...”");
-	output("\n\nYou nod and grab your things. Your whole body reeks of mare musk! You're pretty sure anyone within a mile could smell it. You ask Aina if you can use her shower, and she nods enthusiastically.");
-	output("\n\n“Sure! Just on the right.”");
-	output("\n\nAfter using her shower to clean off, you let out a happy sigh, ruffling a towel over your [pc.hair]. You're feeling refreshed in so many ways!");
+	output("\n\nYou nod and grab your things. Your whole body reeks of mare musk! You're pretty sure anyone within a mile could smell it.");
 	}
 	
 	ainaSexed(1);
@@ -696,13 +714,12 @@ public function ainaSexedFisting():void
 
 	if(ainaIsVirgin())
 	{
-		output("\n\n“M-my first time... I never knew proper mating could be so amazing,” Aina blushes, absentmindedly tucking a messed-up lock behind her ear. “I, um, I'm still feeling kind of lightheaded. Kind of floaty, even. Oh, the mess! Did I really leak out that much? Maybe you should use my shower to clean off. It's on the right.”");
-		output("\n\nTaking her up on the offer, you duck into her shower, cleaning all her fem-cum off. It takes a while! After you get out, Aina approaches you, looking thoroughly embarrassed.");
-		output("\n\n“Um, thank you so much. I really needed that. I-If you're ever in the Res Deck again, maybe look me up? I'd be more than willing to fit you in... um, I mean have you over!”");
+		output("\n\n“M-my first time... I never knew proper mating could be so amazing,” Aina blushes, absentmindedly tucking a messed-up lock behind her ear. “I, um, I'm still feeling kind of lightheaded. Kind of floaty, even. Oh, the mess! Did I really leak out that much?!”");
+		output("\n\nLooking thoroughly embarrassed, the centauress grabs a vacuu-mop. “Um, thank you so much. I really needed that. I-If you're ever in the Res Deck again, maybe look me up? I'd be more than willing to fit you in... um, I mean have you over!”");
+		output("\n\nYou grin and grab your things, leaving Aina to clean up. Given how wet she was, you imagine it's going to take quite a while.");
 	}
 	else{
-		output("\n\nWhen she's caught her breath, Aina turns around, her pale cheeks burning red. “Um, sorry. I got you a bit wet, didn't I? Maybe you should use my shower to clean off? It's on the right.”");
-		output("\n\nAfter using her shower to clean off, you let out a happy sigh, ruffling a towel over your [pc.hair]. You're feeling refreshed in so many ways!");
+		output("\n\n“That was amazing... just like last time...” Aina blushes, absentmindedly tucking a messed-up lock behind her ear. “Um, you know, if you're ever in Res Deck again, feel free to call around. I always love having you over... whether we're talking or, you know, doing other things...”");
 	}
 	
 	ainaSexed(1);
@@ -767,10 +784,8 @@ public function ainaSexedWithAnalWand():void
 	if(flags["AINA_SEXED_WITH_TOY"] == undefined) output(" “You're so much better with my toys than I am");
 	else output(" “You're amazing");
 	
-	output(",” Aina blushes, tucking back her thoroughly messed up locks. It takes you both some time before you're able to stand. Sniffing yourself, you realize your whole body reeks of mare musk! You're pretty sure anyone within a mile could smell it. You ask Aina if you can use her shower, and she nods enthusiastically.");
-	output("\n\n“Sure! Just on the right.”");
-	output("\n\nAfter using her shower to clean off, you let out a happy sigh, ruffling a towel over your [pc.hair]. You're feeling refreshed in so many ways!");
-
+	output(",” Aina blushes, tucking back her thoroughly messed up locks. It takes you both some time before you're able to stand. Sniffing yourself, you realize your whole body reeks of mare musk! You're pretty sure anyone within a mile could smell it.");
+	
 	ainaSexed(1);
 	flags["AINA_SEXED_WITH_TOY"] = true;
 	

--- a/includes/tavros/aina.as
+++ b/includes/tavros/aina.as
@@ -189,13 +189,8 @@ public function helpAina():void
 	clearMenu();
 	
 	addButton(0, "OfferSex", helpAinaWithSex);
-
-	if(pc.intelligence() >= 10 || pc.characterClass == GLOBAL.CLASS_ENGINEER) {
-		addButton(1, "FixToy", helpAinaByFixingHerToy);
-		addButton(2,"Leave", leaveAinaAlone);
-	} else {
-		addButton(1,"Leave", leaveAinaAlone);
-	}
+	if(pc.intelligence() >= 10 || pc.characterClass == GLOBAL.CLASS_ENGINEER) addButton(1, "FixToy", helpAinaByFixingHerToy);
+	addButton(14,"Leave", leaveAinaAlone);
 }
 
 //PC fixes Alina's 
@@ -329,9 +324,7 @@ public function ainaMenu():void
 {
 	clearOutput();
 	showAina();
-	
-	output("met this circle" + ainaMetThisCycle() + "\n\n");
-	
+		
 	if(ainaIsInHeat()) {
 		output("Aina waves and clops over to you. She looks visibly flushed as she brushes back a honey-gold bang. “Hi there, [pc.short]. Sorry if I'm a little scatterbrained right now. I'm, um,");
 	
@@ -550,16 +543,8 @@ public function ainaSexMenu():void
 	clearMenu();
 	addButton(0, "RearEntry", ainaSexedFromBehind);
 	addButton(1, "Fisting", ainaSexedFisting);
-	
-	if(flags["AINA_TALKED_ABOUT_TOYS"]) 
-	{ 
-		addButton(2, "Wand&Anal", ainaSexedWithAnalWand);
-		addButton(3, "Back", ainaMenu);
-	}
-	else
-	{
-		addButton(2, "Back", ainaMenu);
-	}
+	if(flags["AINA_TALKED_ABOUT_TOYS"]) addButton(2, "Wand&Anal", ainaSexedWithAnalWand);
+	addButton(14, "Back", ainaMenu);
 }
 
 public function ainaSexedFromBehind():void

--- a/includes/tavros/aina.as
+++ b/includes/tavros/aina.as
@@ -53,7 +53,7 @@ public function unlockAinasRoom():void {
 	rooms["RESIDENTIAL DECK 15"].southExit = "RESIDENTIAL DECK 18";
 	
 	//refresh map bit to actually show new room
-	generateMapForLocation("RESIDENTIAL DECK 18");
+	generateMapForLocation(currentLocation);
 }
 
 //this function hides her room on the map
@@ -64,7 +64,7 @@ public function lockAinasRoom():void {
 	//unset room - not the prettiest way to do it, but there is no function to remove rooms (?)
 	rooms["RESIDENTIAL DECK 18"] = new RoomClass(this);
 	
-	generateMapForLocation("RESIDENTIAL DECK 15");
+	generateMapForLocation(currentLocation);
 }
 
 //approach Aina in the West Walkway of the residental deck(#15)

--- a/includes/tavros/aina.as
+++ b/includes/tavros/aina.as
@@ -373,17 +373,25 @@ public function ainaTalk():void
 	
 	output("What would you like to talk about with Aina?");
 	
+	ainaTalkNavigation();
+}
+
+public function ainaTalkNavigation(activeTopic:Function = undefined):void {
 	clearMenu();
-	addButton(0, "Her", ainaTalksAboutHerself);
-	
-	if(flags["AINA_TALKED_ABOUT_HERSELF"] == true) addButton(1, "Botany", ainaTalksAboutBotany); 
+	if(activeTopic == ainaTalksAboutHerself) addDisabledButton(0, "Her", "Her", "You just spoke about that.");
+	else addButton(0, "Her", ainaTalksAboutHerself, undefined, "Her", "Ask Aina about herself.");
+	if(activeTopic == ainaTalksAboutBotany) addDisabledButton(1, "Botany", "Botany", "You just spoke about that.");
+	else if(flags["AINA_TALKED_ABOUT_HERSELF"] == true) addButton(1, "Botany", ainaTalksAboutBotany, undefined, "Botany", "Ask Aina about her interest in botany."); 
 	else addDisabledButton(1, "Botany", "Botany", "You don't know her well enough to talk about that.");
-	
-	addButton(2, "Centaur", ainaTalksAboutCentaurs);
-	addButton(3, "Mating", ainaTalksAboutMating);
-	addButton(4, "A.Cashing", ainaTalksAboutCashing);
-	addButton(5, "SexToys", ainaTalkAboutSexToys);
-	addButton(14, "Leave", mainGameMenu);
+	if(activeTopic == ainaTalksAboutCentaurs) addDisabledButton(2, "Centaurs", "Centaurs", "You just spoke about that.");
+	else addButton(2, "Centaurs", ainaTalksAboutCentaurs, undefined, "Centaurs", "Ask Aina about her species.");
+	if(activeTopic == ainaTalksAboutMating) addDisabledButton(3, "Mating", "Mating", "You just spoke about that.");
+	else addButton(3, "Mating", ainaTalksAboutMating, undefined, "Mating", "Ask Aina about her frequent bouts of estrus.");
+	if(activeTopic == ainaTalksAboutACashing) addDisabledButton(4, "A.Cashing", "Astrocashing", "You just spoke about that.");
+	else addButton(4, "A.Cashing", ainaTalksAboutACashing, undefined, "Ask Aina about the random objects decorating her apartment.");
+	if(activeTopic == ainaTalksAboutSexToys) addDisabledButton(5, "SexToys", "Sex Toys", "You just spoke about that.");
+	else addButton(5, "SexToys", ainaTalksAboutSexToys, undefined, "Sex Toys", "Ask Aina about her sex toys.");
+	addButton(14, "Back", ainaMenu);
 }
 
 public function ainaTalksAboutHerself():void
@@ -402,9 +410,7 @@ public function ainaTalksAboutHerself():void
 	flags["AINA_TALKED_ABOUT_HERSELF"] = true;
 	
 	processTime(5);
-	
-	clearMenu();
-	addButton(0, "Back", ainaTalk);
+	ainaTalkNavigation(ainaTalksAboutHerself);
 }
 
 public function ainaTalksAboutBotany():void
@@ -421,9 +427,7 @@ public function ainaTalksAboutBotany():void
 	output("\n\n“One of the farmers gave me a taste. They were so fresh and <i>crisp</i>. It felt like magic. From then, I knew I wanted to be a botanist; to fill worlds with flowers and edible foods. The universe has so much to offer, you know? Stuff we're still finding every day. Combinations and spices, from the sun and the rain, things that we'd never think to add. That's why I love botany.”");
 	
 	processTime(5);
-	
-	clearMenu();
-	addButton(0, "Back", ainaTalk);
+	ainaTalkNavigation(ainaTalksAboutBotany);
 }
 
 public function ainaTalksAboutCentaurs():void
@@ -448,10 +452,7 @@ public function ainaTalksAboutCentaurs():void
 	output("\n\n“Anyway, that's how I became a centaur—selling fast terrible cheeseburgers and watered down soft drink. It gave me a new appreciation for home grown food, at least.”");
 	
 	processTime(5);
-	showAina();
-	
-	clearMenu();
-	addButton(0, "Back", ainaTalk);
+	ainaTalkNavigation(ainaTalksAboutCentaurs);
 }
 
 public function ainaTalksAboutMating():void
@@ -470,12 +471,10 @@ public function ainaTalksAboutMating():void
 	if(ainaIsVirgin()) output(" “Though, you know, I'd prefer to be grinding up against, you know, you.”");
 	
 	processTime(5);
-	
-	clearMenu();
-	addButton(0, "Back", ainaTalk);
+	ainaTalkNavigation(ainaTalksAboutMating);
 }
 
-public function ainaTalksAboutCashing():void
+public function ainaTalksAboutACashing():void
 {
 	clearOutput();
 	showAina();
@@ -499,12 +498,10 @@ public function ainaTalksAboutCashing():void
 	output("\n\n“Well, yeah, you could sort of say that,” you cough.");
 	
 	processTime(5);
-	
-	clearMenu();
-	addButton(0, "Back", ainaTalk);
+	ainaTalkNavigation(ainaTalksAboutACashing);
 }
 
-public function ainaTalkAboutSexToys():void
+public function ainaTalksAboutSexToys():void
 {
 	clearOutput();
 	showAina();
@@ -522,10 +519,9 @@ public function ainaTalkAboutSexToys():void
 	
 	processTime(5);
 	
-	clearMenu();
-	addButton(0, "Back", ainaTalk);
-	
 	flags["AINA_TALKED_ABOUT_TOYS"] = true;
+	
+	ainaTalkNavigation(ainaTalksAboutSexToys);
 }
 
 public function ainaTea():void

--- a/includes/tavros/aina.as
+++ b/includes/tavros/aina.as
@@ -1,0 +1,801 @@
+
+//Available Flags
+
+//HELPED_AINA:					If the PC helped Aina during their first encounter
+//AINA_WAND_FIXED:				If the PC helped her by fixing her sex toy (true, false or undefined)
+//AINA_SEXED:					If the PC helped her by sexing her up, but also keeps counting further encounters (int, 0+)
+//AINA_DAY_MET:					The day Aina was first met, used to calculate her heat status (int, 1+)
+//AINA_LAST_DAY_MET:			The last day Aina was met, needed for some responses in conjunction with heat (int, 1+)
+//AINA_TALKED_ABOUT_HERSELF:	If the player asked Aina about herself in the past (true or undefined)
+//AINA_TALKED_ABOUT_TOYS:		If the player asked Aina about her sextoys (true or undefined)
+//AINA_SEXED_WITH_TOY:			If the player did her Anal&Wand scene in the past (true or undefined)
+
+
+//Heat mechanics: 
+
+//Aina is in heat for 7 days, followed by 14 days she is not in heat. Starting from the day the player talks to her.
+//To calculate if she is in heat the flag AINA_DAY_MET is used in conjunction with the current day.
+//Rather simple implementation, ignoring minutes, but since she is a minor NPC,
+//hooking into the time system itself seems unneeded as there are no plans to immediately act on a status change.
+
+public function showAina(nude:Boolean = false):void
+{
+	showName("\nAina");
+	author("JimThermic");
+}
+
+//check if Aina is outside her apartment in the West Walkway of the residental deck (room #15)
+//render button only if Aina wasn't met before
+public function checkIfAinaIsAround():void 
+{
+	if(flags["HELPED_AINA"] == undefined) 
+	{
+		addButton(0,"Centauress", approachAinaOnTheWalkway);
+	}
+}
+
+//this function displays AinasRoom on the map
+public function unlockAinasRoom():void {
+	//define Room
+	rooms["RESIDENTIAL DECK 18"] = new RoomClass(this);
+	rooms["RESIDENTIAL DECK 18"].roomName = "AINA'S\nAPARTMENT";
+	rooms["RESIDENTIAL DECK 18"].description = "Aina's apartment is incredibly spacious with large open spaces and doorways. What does fill it is tastefully chosen, from the expressive pot-plants and paintings to the cushy centaur-friendly couches that lie about. There's also seating for visitors of the two-legged variety, particularly around a friendly looking coffee table.";
+	rooms["RESIDENTIAL DECK 18"].planet = "TAVROS STATION";
+	rooms["RESIDENTIAL DECK 18"].system = "SYSTEM: KALAS";
+	rooms["RESIDENTIAL DECK 18"].northExit = "RESIDENTIAL DECK 15";
+	rooms["RESIDENTIAL DECK 18"].moveMinutes = 1;
+	rooms["RESIDENTIAL DECK 18"].addFlag(GLOBAL.INDOOR);
+	rooms["RESIDENTIAL DECK 18"].addFlag(GLOBAL.PRIVATE);
+	rooms["RESIDENTIAL DECK 18"].addFlag(GLOBAL.NPC);
+	rooms["RESIDENTIAL DECK 18"].runOnEnter = ainaApartmentMeet
+		
+	//add door towards Aina's apartment
+	rooms["RESIDENTIAL DECK 15"].southExit = "RESIDENTIAL DECK 18";
+	
+	//refresh map bit to actually show new room
+	generateMapForLocation("RESIDENTIAL DECK 18");
+}
+
+//this function hides her room on the map
+public function lockAinasRoom():void {
+	//remove door towards Aina's apartment
+	rooms["RESIDENTIAL DECK 15"].southExit = null;
+	
+	//unset room - not the prettiest way to do it, but there is no function to remove rooms (?)
+	rooms["RESIDENTIAL DECK 18"] = new RoomClass(this);
+	
+	generateMapForLocation("RESIDENTIAL DECK 15");
+}
+
+//approach Aina in the West Walkway of the residental deck(#15)
+public function approachAinaOnTheWalkway():void
+{
+	clearOutput();
+	showAina();
+	
+	//set basic flags
+	flags["AINA_DAY_MET"] = days;
+	flags["AINA_LAST_DAY_MET"] = days;
+	flags["AINA_SEXED"] = 0;
+	flags["AINA_WAND_FIXED"] = false;
+	
+	//begin text output
+	output("Standing in the hall is a chestnut-colored centauress, wearing a worried look on her face. As soon as she spots you, her tawny eyes light up and she canters over, her hooves clip-clopping against the hard thoroughfare surface.");
+	output("\n\n“H-hi! Sorry, I'm kind of approaching you out of nowhere, even though you're a stranger... but, uh, I've got a problem only a stranger can fix. Can you help me out—?” she asks, clasping her pale hands against her chest.");
+	output("\n\nShe's definitely not a Leithan; modded, perhaps? Her human half is covered in a champagne-colored sweater and a cream linen skirt, the hem falling down to her horse-like knees. It utterly fails to cover up her tauric body, though, or her bristly horse tail. Her honey-blonde hair is tied back in a far less literal ponytail, secured with a lace ribbon.");
+
+	if(pc.isBimbo()) output("\n\n“Oh, sure! What's the favor?” you ask, eyes glimmering. Will it involve sex, you wonder? You really hope it involves sex! All your favorite things do.");
+	else if(pc.isBro()) output("\n\n“Oh, sure! What's the favor?” you ask, eyes glimmering. Will it involve sex, you wonder? You really hope it involves sex! All your favorite things do.");
+	else {
+		output("\n\n“... What's the favor?” you");
+		
+		if(pc.isNice()) output(" warmly ask.");
+		else if(pc.isMischievous()) output(" ask, quirking a brow.");
+		else output(" you bluntly ask.");
+	}
+	
+	output("\n\n“Uumm, it's kind of hard to explain,” the ponytailed centauress replies. She quickly looks around. “Particularly here in the open where my neighbours are listening. Can we go inside—?”");
+	
+	output("\n\nNow that you're standing close to her, you swear you can smell a potent, feminine musk. With each flick of her tail, it becomes that much more intense. It hotly surges through your veins and down into your loins, making your");
+
+	if(!pc.hasCock() && !pc.hasVagina()) output(" hips shiver.");
+    else if(pc.hasCock() && !pc.hasVagina()) output(" [pc.cocks] pointedly stiffen.");
+    else if(!pc.hasCock() && pc.hasVagina()) output(" [pc.pussies] ache.");
+    else output(" [pc.cocks] pointedly stiffen and your [pc.pussies] ache.");
+
+	output("\n\nWhat do you do—?");
+	
+	processTime(2);
+	
+	clearMenu();
+	addButton(0, "HelpHer", helpAina);
+	addButton(1, "Don'tHelp",dontHelpAina);
+}
+
+//PC decided to not help Aina. Her room is not unlocked and PC never sees her again.
+public function dontHelpAina():void
+{
+	clearOutput();
+	showAina();
+	
+	flags["HELPED_AINA"] = false;
+	rooms["RESIDENTIAL DECK 15"].removeFlag(GLOBAL.NPC);
+	
+	output("The chestnut-colored centauress squirms on the spot. “O-oh-okay. Thank you anyway—!”");
+	output("\n\nShe gallops off, probably to look for someone else to help her with her plight.");
+	
+	processTime(1);
+	
+	clearMenu();
+	addButton(0,"Next",mainGameMenu);
+}
+
+//PC decides to help Aina
+public function helpAina():void
+{
+	//remove Aina's icon from walkway, unlock her room and port player there
+	rooms["RESIDENTIAL DECK 15"].removeFlag(GLOBAL.NPC);
+	unlockAinasRoom();
+	currentLocation = "RESIDENTIAL DECK 18";
+	
+	clearOutput();
+	showAina();
+	
+	output("The chestnut-covered centauress claps her hands together. There's a bright, relieved smile on her face, and her equine ears flicker. “Thank you! I'm sorry to just ask you out of nowhere, but I'm really in a bind here,” she answers.");
+	output("\n\n“Oh--I'm Aina, by the way! Sorry, I forgot to introduce myself.”");
+	output("\n\n“[pc.name],” you");
+	
+	if(pc.isBimbo()) output(" giggle");
+	else if(pc.isTreated()) output(" grunt");
+	else output(" reply");
+	
+	output(" following her inside her apartment. Once inside the two big barn-like doors, you're surprised at how classy and spacious it is. It's full of tastefully selected pot plants and paintings, not to mention centaur-friendly couches.");
+	
+	if(pc.isTaur()) output(" As a taur yourself, you always appreciate tailored furniture.");
+	
+	output(" She gallops over to a coffee table and gestures to it. Her cheeks are visibly flushed.");
+	output("\n\n“... Um, I dropped something under here. Well, more to the point, it fell and rolled under. I can't reach it, it's too low...” Aina explains, squirming on the spot. Whatever it is, it seems important.");
+	
+	if(pc.isTaur())
+	{	
+		if(pc.isBimbo()) output("\n\n“Oh wow, sounds like quite a pickle! ");
+		else if(pc.isTreated()) output("\n\n“Humph! So you ask the big, tough " + pc.mf("guy", "girl") + " to handle it? ");
+		else if(pc.isNice()) output("\n\n“I'm sorry, I don't think I can either. ");
+		else if(pc.isMischievous()) output("\n\n“We're two peas in a pod, hon. ");
+		else output("\n\n“So you ask another taur? Smart.");
+		
+		output(" I'm kind of in the same predicament you are...” You look around and spot a broom cupboard. “...Got any long objects in there? We might be able to use one to fish it out.”");
+		output("\n\n“Oh, of course—!” Aina facepalms, looking genuinely embarrassed. “... Why didn't I think of that?”");
+		output("\n\nYou go and get a broom from the cupboard, particularly long and taur-friendly. Hooking it under the table, you fish out the object. As it rolls into view, you pointedly blink. From its dome-like head and the words 'Levi-wand' on the side, it's safe to assume it's a sex toy.");
+		output("\n\nThe blonde-haired centauress leans over and picks it up, her face turning several shades redder than before. ");
+	
+	}
+	//not a taur
+	else 
+	{
+		output("\n\nSince the task is incredibly easy for you, you bend down and fish around for whatever this object is. You feel your fingers make contact. Pulling it out, you blink at the large mechanical object in your hands. From its dome-like head and the words 'Levi-wand' on the side, it's safe to assume it's a sex toy.");
+		output("\n\nYou offer it up, and the blonde-haired centauress takes it off your hands. Her face is several shades redder than it was before.");	
+	}
+	
+	output(" “S-sorry, it's that time of the month; I'm in estrus, so I REALLY need this. That's why I wanted to ask a stranger, not someone I knew...” She flicks the 'On' switch a few times, but nothing happens. “Oooohh no... don't tell me this is happening. Come ooonnn!”");
+	output("\n\n“What's the matter?”");
+	output("\n\n“I KNEW I should have gone down to the merchant deck, but I was too embarrassed; I bought this on the extranet, and it's a dud!” Aina whimpers, clutching the defective toy to her cardigan-clad chest. “... It only ran for five minutes, then cut out~!”");
+	output("\n\nThe centauress looks like she's about to cry. Her equine tail flicks and once more you're hit with a whumping wave of her musky mare-scent. As you breathe deeply, your mind is subsumed with arousal, drawing you into a scent-induced haze. Suddenly her equine rump is looking <i>really</i> attractive");
+	
+	if(pc.isTaur()) output(" and thoroughly mountable...");
+	else output(", even though you're not a taur!");
+	
+	processTime(10+rand(5));
+	clearMenu();
+	
+	addButton(0, "OfferSex", helpAinaWithSex);
+
+	if(pc.intelligence() >= 10 || pc.characterClass == GLOBAL.CLASS_ENGINEER) {
+		addButton(1, "FixToy", helpAinaByFixingHerToy);
+		addButton(2,"Leave", leaveAinaAlone);
+	} else {
+		addButton(1,"Leave", leaveAinaAlone);
+	}
+}
+
+//PC fixes Alina's 
+public function helpAinaByFixingHerToy():void 
+{
+	clearOutput();
+	showAina();
+	
+	output("You keenly inspect the sex toy. Flipping open part of the casing, you fiddle around with the internal wiring. It's actually a pretty simple fix. After clicking it closed, you toss it to Aina, who catches it in both hands.");
+	
+	if(pc.isBimbo()) output("\n\n“It was a simple fix! I just attached the blue thingy to the green thingy, and now it should be all good for sexy fun times!”");
+	else if(pc.isBro()) output("\n\n“Fix'd it. Ain't no big thing for [pc.name] Steele.”");
+	else if(pc.isNice()) output("\n\n“There you go, ma'am. Your problems are solved.”");
+	else if(pc.isMischievous()) output("\n\n“All done. [pc.name] Steele: galactic adventurer and sex-toy repair.”");
+	else output("\n\n“There. Good as new. Try not to break it next time.”");
+	
+	output("\n\nThe honey-blonde centauress clicks the wand on, and it whirrs in her grasp. With blushing cheeks, she bows to you. “T-thank you so much. Honestly, this solves all my problems. I'm meant to be studying for an exam, and I just can't concentrate. You've really saved my hide!”");
+	output("\n\n“Anytime you want to stop around, feel free to do so. I brew a mean cup of tea. Um... but if you don't mind, could you excuse me? Got to, you know, do some stuff... “");
+	output("\n\nYou grin and head off, leaving the centauress to have her alone time, your good deed done.");
+	
+	flags["HELPED_AINA"] = true;
+	flags["AINA_WAND_FIXED"] = true;
+	
+	processTime(15+rand(10));
+	
+	clearMenu();
+	addButton(0,"Next",mainGameMenu);
+}
+
+public function helpAinaWithSex():void
+{
+	clearOutput();
+	showAina();
+	
+	//since there is no leave button anyway, set Aina helped to true
+	flags["HELPED_AINA"] = true;
+	
+	output("What do you suggest?");
+	
+	clearMenu();
+	
+	if((pc.hasCock() && pc.biggestCockLength() >= 5) && !pc.isTaur()) addButton(0, "RearEntry", ainaSexedFromBehind);
+	else addDisabledButton(0, "RearEntry", "RearEntry", "You need a cock to do this and not be a taur.");
+	
+	addButton(1, "Fisting", ainaSexedFisting);
+}
+
+//PC leaves Aina's apartment without helping her. 
+//Her room is not unlocked and PC never sees her again.
+public function leaveAinaAlone():void
+{
+	currentLocation = "RESIDENTIAL DECK 15";
+	lockAinasRoom();
+	clearOutput();
+	
+	flags["HELPED_AINA"] = false;
+	
+	output("With incredible difficulty, you shake your head of the musk-induced lust threatening to take control of you, and hastily bid her adieu. The whimpering centauress still thanks you for your help, waving as you make a quick dash for the door. As soon as you're out, you take in a deep breath of fresh, pheromone-free air. Whew!");
+	output("\n\nIt takes a few minutes to get back to normal, though you still feel a palpable tingling in your loins.");
+	
+	pc.lust(20);
+	processTime(2);
+	
+	clearMenu();
+	addButton(0,"Next",mainGameMenu);
+}
+
+//returns true/false depending if Aina is currently in heat
+public function ainaIsInHeat():Boolean {
+	var day_met:int = flags["AINA_DAY_MET"];
+	
+	//Aina is in heat for 7 days, followed by 14 days she is not in heat, her full circle 21 days.
+	//Subtracting the day she was met from the current day gives the time the player knew her in days.
+	//A modulo operation with 21 gives the days of her new cycle -1 as a remainder. 
+	//Examples: 
+	//Meeting her on day 5: 5(days) - 5(day_meet) = 0 % 21 = 0			(#1 day of cyclce [5])
+	//Meeting her again on day 8: 8(days) - 5(day_meet) = 3 % 21 = 3	(#4 day of cycle [5, 6, 7, 8])
+	//Meeting her again on day 21: 26(days) - 5(day_meet) = 21 % 21 = 0 (#1 day of cyclce again)
+	var days_in_new_cycle:int = Math.round((days - day_met) % 21);
+	
+	if(days_in_new_cycle >= 0 && days_in_new_cycle <= 6) return true;
+	else return false;
+}
+
+//returns true/false depending if Aina was met in this cycle
+public function ainaMetThisCycle():Boolean {
+	var day_met:int = flags["AINA_DAY_MET"];
+	var day_last_met:int = flags["AINA_LAST_DAY_MET"];
+	
+	var last_cycle:int = Math.floor((day_last_met - day_met ) / 21);
+	var current_cycle:int = Math.floor((days - day_met ) / 21);
+	
+	if(last_cycle == current_cycle) return true;
+	else return false;
+}
+
+//returns true/false depending if Aina was last seen when in heat
+public function ainaLastMetInHeat():Boolean {
+	var day_met:int = flags["AINA_DAY_MET"];
+	var day_last_met:int = flags["AINA_LAST_DAY_MET"];
+	
+	var days_in_old_cycle:int = Math.round((day_last_met - day_met) % 21);
+	
+	if(days_in_old_cycle >= 0 && days_in_old_cycle <= 6) return true;
+	else return false;
+}
+
+//returns true/false depending if Aina is a virgin or not
+public function ainaIsVirgin():Boolean {
+	if(flags["AINA_SEXED"] > 0) {
+		return false;
+	} else {
+		return true;
+	}
+}
+
+//increase the amount aina was sexed by x
+public function ainaSexed(times:int):void {
+	if(flags["AINA_SEXED"] == undefined) flags["AINA_SEXED"] = 0;
+	flags["AINA_SEXED"] += times;
+}
+
+//render Button for meeting Aina in her apartment on the residential deck(#18)
+public function ainaApartmentMeet():void 
+{
+	addButton(0,"Aina",ainaMenu);
+}
+
+//approaching Aina in her apartment
+public function ainaMenu():void
+{
+	clearOutput();
+	showAina();
+	
+	output("met this circle" + ainaMetThisCycle() + "\n\n");
+	
+	if(ainaIsInHeat()) {
+		output("Aina waves and clops over to you. She looks visibly flushed as she brushes back a honey-gold bang. “Hi there, [pc.short]. Sorry if I'm a little scatterbrained right now. I'm, um,");
+	
+		if(ainaMetThisCycle()) output(" still in heat.”");
+		else output(" in heat again.”");
+		
+		output("\n\nYou can definitely smell it! Every time her equine tail flicks, you're hit with a fresh wave of her musky mare-scent. The moment you get a whiff of her juicy cunt, you feel the instinct to <i>breed</i> her like crazy.");
+	}
+	else {
+		output("Aina warmly waves and clops over to you, brushing back a honey-gold bang. “Hey there!");
+		
+		if(ainaMetThisCycle() && ainaLastMetInHeat()) output(" Finally out of heat, thank goodness.");
+		else output(" Always good to see your face around here.");
+		
+		output("\n\n“I just finished brewing up a pot of tea—did you want some?”");
+	}
+	
+	//Upate the last time Aina was met
+	flags["AINA_LAST_DAY_MET"] = days;
+	
+	processTime(2);
+	
+	clearMenu();
+	addButton(0, "Appearance", ainaAppearance);
+	if(!ainaIsInHeat()) addButton(1, "Talk", ainaTalk);
+	else addDisabledButton(1, "Talk", "Talk", "Aina must not be in heat to talk to her.");
+	//addDisabledButton(2, "Tea", "Tea", "Aina must not be in heat to enjoy a cup of tea."); //Listed in DOC but no text was supplied for it
+	addButton(2, "OfferSex", ainaSexMenu);
+	addButton(3,"Leave",mainGameMenu);
+}
+
+public function ainaAppearance():void
+{
+	clearOutput();
+	showAina();
+	
+	output("Aina is what you'd call the girl next door, if the girl next door was a chestnut-colored centaur. From her champagne-colored sweater to her long cream-linen skirt, she hardly flashes her assets. That said, they're definitely there; it's hard to miss the curvaceous swell of her breasts.");
+	output("\n\nHer honey-blonde hair is tied back with a lace ribbon, hanging down her back in a ponytail. Her tawny eyes are soft edged, matching the warm smile usually lighting up her lips. Her fair skin is soft and youthful.");
+	output("\n\nHer rump, like that of any centauress, is sizably huge. Even though her hem is long, it does nothing to cover it up, leaving her puffy-lipped equine pussy openly exposed. She doesn't seem self-conscious about it, holding her human and tauric halves to different standards.");
+}
+
+public function ainaTalk():void
+{
+	clearOutput();
+	showAina();
+	
+	output("What would you like to talk about with Aina?");
+	
+	clearMenu();
+	addButton(0, "Her", ainaTalksAboutHerself);
+	
+	if(flags["AINA_TALKED_ABOUT_HERSELF"] == true) addButton(1, "Botany", ainaTalksAboutBotany); 
+	else addDisabledButton(1, "Botany", "Botany", "You don't know her well enough to talk about that.");
+	
+	addButton(2, "Centaur", ainaTalksAboutCentaurs);
+	addButton(3, "Mating", ainaTalksAboutMating);
+	addButton(4, "A.Cashing", ainaTalksAboutCashing);
+	addButton(5, "SexToys", ainaTalkAboutSexToys);
+	addButton(14, "Leave", mainGameMenu);
+}
+
+public function ainaTalksAboutHerself():void
+{
+	clearOutput();
+	showAina();
+	
+	output("You ask Aina a little bit about herself. You're a little curious to know more about the youthful-looking centauress.");
+	output("\n\n“About me? Geez. I never know how to answer that question well,” Aina replies, rubbing the back of her neck. “When they asked me for my college entry, I froze on the spot.”");
+	output("\n\n“You're a college student?”");
+	output("\n\n“Yeah. I'm studying interstellar botany, though I'm only a sophomore. And before you ask, no, I'm not studying botany because I want to eat plants. Not that I don't eat plants. I mean, I do, but that's not why I want to be a botanist,” she pouts.");
+	output("\n\n“Why study all the way out here? Is there a college here on the station?”");
+	output("\n\n“Yes, but I'm not a student of it. I'm actually doing my botany certificate by holo-edu at Arda University on Ekurana. There's an applied research course, though, and it operates out of Tavros. We get to examine all the exotic flowers and plants that rushers bring back. It's pretty exciting!”");
+	output("\n\n“That said, it can be rough sometimes. I took out a massive student loan to help me rent this apartment. I've also got a part time job selling flowers, herbs, and tea over the extranet. Growing my own food really helps me get by, too. Advantages of being a centaur; no need for meat in my diet!”");
+
+	flags["AINA_TALKED_ABOUT_HERSELF"] = true;
+	
+	processTime(5);
+	
+	clearMenu();
+	addButton(0, "Back", ainaTalk);
+}
+
+public function ainaTalksAboutBotany():void
+{
+	clearOutput();
+	showAina();
+	
+	output("You ask Aina about her interest in botany. She grins and trots over to a sealed off room, pressing her pale hand against a palm-pad. With a whoosh, the door opens, revealing a separate indoor greenhouse. Rows and rows of vibrant plant life line the shelves. As you approach, a symphony of floral scents hit your senses. You reel in olfactory bliss!");
+	output("\n\n“This is my growing area. Half are my class projects, while the rest are for pleasure, selling, or food. I've got cuttings from all sorts of planets, even Earth! I've got some lovely lavender and coriander, not to mention quite a few teas.”");
+	output("\n\nShe picks some herbal leaves and hands them to you. Crisp, strong, and nostalgic; it reminds you of your home on Terra. “... It smells so fresh. Nothing like the replicated stuff.”");
+	output("\n\nAina screws up her nose. “Oh, eugh, no! Replicator food is the <i>worst</i>. I mean, if I had to live on it, I would, but nothing beats authentic, grown food. Even synthetic soil alters the taste. I try to source real soil for growing and use water with natural bacteria from the plant's home planet. Every little thing makes a difference, you know?”");
+	output("\n\n“Sounds intricate,” you admit, looking at the aromatic herbs. Such a small thing takes so much work to replicate in space. Food with these must taste amazing. “So, is the smell and taste why you love botany?”");
+	output("\n\n“That's part of it. I grew up on Vaernes. It's a core world, deep in the Rosette Nebula,” Aina stroked a leafy plant, “Most of the planet is covered in continental cities. Half the food supply is imported from a sister planet. We went on a class trip when I was in primary school. I'd never seen so much open space; so far and so wide, just filled with beautiful, growing plants! They were just Ma'ora beans, but it moved me.”");
+	output("\n\n“One of the farmers gave me a taste. They were so fresh and <i>crisp</i>. It felt like magic. From then, I knew I wanted to be a botanist; to fill worlds with flowers and edible foods. The universe has so much to offer, you know? Stuff we're still finding every day. Combinations and spices, from the sun and the rain, things that we'd never think to add. That's why I love botany.”");
+	
+	processTime(5);
+	
+	clearMenu();
+	addButton(0, "Back", ainaTalk);
+}
+
+public function ainaTalksAboutCentaurs():void
+{
+	clearOutput();
+	showAina();
+	
+	output("You ask Aina what her birth-species is, and if she was born a centaur.");
+	output("\n\n“Nope! I was born a human. This was very costly. My parents threw a fit when I told them I wanted to get gene-modded,” Aina winces, brushing back a blonde bang. “I think they wanted to make sure I wasn't just going through a phase.”");
+	output("\n\nA phase? You ask why they'd think that. Aina smiles and gives a shrug.");
+	output("\n\n“I went to a fairly well-off school on Vaernes. Every so often, some kid would come to school with a gene-mod that their parents had forked out for, just so they could be a special snowflake. Of course, then all their friends want to follow suit. My parents wanted to make sure it wasn't just some fad.”");
+	output("\n\n“I understand it, though. Being a taur's not an easy lifestyle.");
+	
+	if(pc.isTaur()) output(" I mean, you know, right?");
+	
+	output(" Most stuff is built for bipeds, with a little bit of afterthought given for everyone else. I mean, just sitting down in a shuttle is a hassle. There's like, usually two taur seats and a ton for everyone else. You've pretty much got to get used to standing until your hooves sting.”");
+	output("\n\nSo why bother becoming a taur, you ask?");
+	output("\n\n“It might sound a little silly, but I like to think I've always been a centaur, deep down. I've always loved natural things; plants, running, open spaces. A real problem when you live on a planet covered in giga-cities.”");
+	output("\n\n“I first found out about centaurs when I was playing a fantasy game a friend leant me in high school. It had this beautiful centaur mare in it, and even though she was a bit character, I just found myself identifying so much with her and her species. I read up on the myths and fiction...I ended up visiting centaur extranet sites a lot.”");
+	output("\n\n“It got so bad that my parents caught me, um, masturbating to stallion porn...” Aina blushes, squirming on the spot. “... I-I was mortified. There I was, legs spread and fingers deep, touching myself to a life-size horseman holo. I was <i>so</i> grounded it wasn't funny. It didn't stop me. I ended up on virtual boards, talking to others who'd gone centaur and never looked back. They gave me the confidence to make the change.”");
+	output("\n\n“I walked in, told my parents it was happening one way or another, and that was that. There was shouting, but I stood my ground. They said they weren't paying for it, so I got a part-time job at McChow Hut. It took me three years to save up the money. Sometimes I thought about just taking out a loan, but I was too scared of defaulting.”");
+	output("\n\n“Anyway, that's how I became a centaur—selling fast terrible cheeseburgers and watered down soft drink. It gave me a new appreciation for home grown food, at least.”");
+	
+	processTime(5);
+	showAina();
+	
+	clearMenu();
+	addButton(0, "Back", ainaTalk);
+}
+
+public function ainaTalksAboutMating():void
+{
+	clearOutput();
+	showAina();
+	
+	output("You ask Aina about her frequent bouts of estrus. It seems pretty problematic, by the looks of things.");
+	output("\n\nThe honey-blonde student shakes her head. “O-oh no, not really! I mean, it's just a part of nature, right? The urge to mate exists in humans, too, and especially species like ausar and leithans. It's just nature's way of saying 'Mate already, girl!' I-I mean, it's pretty manageable, especially since you");
+	
+	if(ainaIsVirgin()) output(" came and helped me out.”");
+	else output(" fixed my toy.”");
+	
+	output("\n\n“If anything, when I'm in heat and my needs are, you know, met, I feel this dopey, absolutely happy feeling... it's a bit hard to describe? Like what I'm doing is <i>so</i> right. So long as I'm able to get off, I'm good to still do most things... though I find myself grinding against things a <i>lot</i> more often,” Aina blushes.");
+
+	if(ainaIsVirgin()) output(" “Though, you know, I'd prefer to be grinding up against, you know, you.”");
+	
+	processTime(5);
+	
+	clearMenu();
+	addButton(0, "Back", ainaTalk);
+}
+
+public function ainaTalksAboutCashing():void
+{
+	clearOutput();
+	showAina();
+	
+	output("You spot a shelf in Aina's apartment cluttered with strangely random nick-knacks. There's a little toy ausar soldier, an ancient-looking flint and steel lighter, a blue bandanna... it all seems completely out of place in her otherwise neat, stylish apartment.");
+	
+	if(pc.isBimbo()) output("\n\n“Oh hey, what's with those thingy-things over there?” ");
+	else if(pc.isBro()) output("\n\n“Yo, babe. What's with the crap on the shelf?” ");
+	else output("\n\n“That's a strange bunch of stuff on that shelf. What's with it?”");
+	
+	output(" you ask, gesturing for emphasis.");
+	output("\n\nThe centauress looks over at the shelf, then turns back, golden eyes glinting excitedly. “Oh, you're asking about my swag? I've collected it from all over the galaxy!”");
+	output("\n\n“Your... swag?”");
+	output("\n\n“Yeah, my swag! It's from Astrocaching. It's a hobby of mine. Do you know it?”");
+	output("\n\nYou shake your head. Aina pulls a small palm-size device and shows it to you. With a click, a three-dimensional representation of the station floats above the screen, with a green dot showing her position. There's also a few smaller dots in blue. It's a CPS—a cosmos positioning system.");
+	output("\n\n“Astrocaching is a real-world, galactic treasure hunting game using SPS devices, dating back to Terra. It's loads of fun. Basically, people leave astrocaches around the galaxy, then drop some coordinates on the extranet. People navigate there and attempt to find the nearby cache nearby. It's just like being a real treasure hunter!”");
+	output("\n\n“When you get there, there's always a digital logbook inside, where you sign down your name. There's also swag; things people have left behind in the cache. You can take anything you want, but you've got to leave something in its place of equal value. See, I found that stuff in the caches I opened and took them, but I left something small in trade for the next person to take.”");
+	output("\n\nYou ask her if the blue dots on Tavros are astrocache coordinates. The centauress nods and touches one. Suddenly a small screen pops up, with not only the general area the cache is hidden, but its type, size, and difficulty. This one appears to be three stars.");
+	output("\n\n“Some are harder than others. I've only got as high as two stars. I hear you can find some neat swag in the bigger ones. There's ones as small as a bottle, others large as a shipping container. You don't really do it for the swag, though, but more for the adventure, you know? Sometimes it takes hours to find a cache, and you find someone's hidden it as a fake log. Other times, there's riddles to find caches, or ones that lead to <i>other</i> caches.”");
+	output("\n\n“Have you ever been on a treasure hunt like that?”");
+	output("\n\n“Well, yeah, you could sort of say that,” you cough.");
+	
+	processTime(5);
+	
+	clearMenu();
+	addButton(0, "Back", ainaTalk);
+}
+
+public function ainaTalkAboutSexToys():void
+{
+	clearOutput();
+	showAina();
+	
+	output("You notice Aina's collection of sex toys in an open drawer. Most of them are clitoral wands, though there's a few anal toys as well. Aina notices where your gaze has gone and her cheeks flush.");
+	output("\n\n“That's... that's not supposed to be open,” she stammers out, trotting quickly over to the drawer. Before she can shut it, you ask her about all her toys. The centauress pauses and pulls out one of the butt-plugs, nervously playing with it in her hands. Why has she got so many of them?");
+	output("\n\n“... Well, it's been really tough to find a good one. I'm too nervous to try the centaur-specific ones... you know, the ones that float with a mind of their own? That's way too scary, like, what if it goes out of control? It's kind of like having a <i>ghost</i> floating around.”");
+	output("\n\n“I'd rather do it myself or have someone else involved, you know?”");
+	output("\n\nYou ask her about the butt-plugs, anal dildoes and beads she owns. Some of the butt-plugs are the size of footballs! Does she enjoy that sort of thing?");
+	output("\n\nAina squirms and gives a nervous nod. “Yeah, I mean, I didn't want to give up my virginity to a toy, so I started experimenting in... you know, other areas. I really like the sensation of being filled.”");
+	output("\n\n“Problem is, ever since I became a centaur, I can take in a lot back there. It used to be a lot easier—a few fingers would be plenty.”");
+	output("\n\n“Now, I need really big stuff like this. It's not all bad though. Some of them vibrate, which actually helps with my studying.”");
+	output("\n\n“Which one's your favorite?” you ask. Aina brushes back one of her bangs and then shly picks up a translucent toy with both hands. The eighteen inch see-through horse cock takes both hands to hold, and even then it's spilling out of her grasp. Even though it's transparent, every vein and groove of the animalistic shaft is realistic, with the exception of the flared and round suction cup at its base.");
+	output("\n\n“This one, definitely. It's hands free, though I've only used it, well, in my rump. Once I put it between my breasts, which was kind of nice. After cleaning it, of course,” Aina quickly adds. The saleswoman said it can be slipped into a strap-on belt, which came with it. I prefer to just slap it against the shower wall and use it. It's easy to clean up after I get all messy.” She blushes. “Good thing it's waterproof.”");
+	
+	processTime(5);
+	
+	clearMenu();
+	addButton(0, "Back", ainaTalk);
+	
+	flags["AINA_TALKED_ABOUT_TOYS"] = true;
+}
+
+public function ainaTea():void
+{
+	//No text provided in DOC
+}
+
+public function ainaSexMenu():void
+{
+	clearOutput();
+	showAina();
+	
+	output("...What do you suggest?");
+	
+	clearMenu();
+	addButton(0, "RearEntry", ainaSexedFromBehind);
+	addButton(1, "Fisting", ainaSexedFisting);
+	
+	if(flags["AINA_TALKED_ABOUT_TOYS"]) 
+	{ 
+		addButton(2, "Wand&Anal", ainaSexedWithAnalWand);
+		addButton(3, "Back", ainaMenu);
+	}
+	else
+	{
+		addButton(2, "Back", ainaMenu);
+	}
+}
+
+public function ainaSexedFromBehind():void
+{
+	clearOutput();
+	showAina();
+	
+	if(ainaIsInHeat()) 
+	{
+		output("You offer your services at relieving her 'tensions'. She definitely seems like she needs it. Plus, just being this close to her has gotten you all worked up as well.");
+		
+		if(ainaIsVirgin()) 
+		{
+			output("\n\n“Ruh-really? But I've never been with anyone but a toy—!” Aina exclaims. As much as she's blushing, she's also squirming on the spot. Eventually, she can't handle it anymore, giving into her lust, “...Okay, you can mount me, but be gentle, okay?”");
+		
+			if(pc.isNude()) output("\n\nWith you already naked and ready, ");
+			else output("\n\nAs you strip off,");
+			
+			output(" the pretty centaur turns her big backside towards you and lifts her tail. Her huge horse-like sex is extremely puffy and wet, flaring invitingly at you. As you're hit with a fresh wave of her potent musky scent, you reel with delight, your [pc.cocksLight] immediately stiffening with primitive desire!");
+		}
+		//not a virgin
+		else
+		{
+			output("\n\n“I suppose we've done");
+			
+			if(flags["AINA_SEXED"] >= 5) output(" it so many times, you're practically my mate now...” ");
+			else output(" it before, another time wouldn't hurt...” ");
+			
+			if(pc.isCrotchGarbed()) output("You strip off as she");
+			else output(" She");
+			
+			output(" turns her big backside towards you, pointedly lifting her tail. Her huge horse-like sex is extremely puffy and wet, flaring invitingly at you. As you're hit with a fresh wave of her potent musky scent, you reel with delight and your loins stiffen with primitive desire.");
+		}
+	}
+	//not in heat
+	else 
+	{
+		output("You move over and stroke Aina's shapely backside, suggesting that maybe the two of you could mate again? The honey-blonde centauress blushes, not rejecting your advances. If anything, her equine tail is swishing a little excitedly, and you can smell the slightest stirring of her feminine scent in the air; is she getting wet from just you touching her?");
+		output("\n\n“U-um, I suppose we've done it");
+		
+		if(flags["AINA_SEXED"] >= 5) output(" it so many times, you're practically my mate...” ");
+		else output(" it before, another time wouldn't hurt...” ");
+		
+		output(" Aina breathily exclaims, clasping her hands to her chest. Timidly, she turns her big backside towards you, and slowly lifts her tail. You grin as you see her huge horse-like sex, already looking a little puffy and wet. Her mare sex flares, whumphing you with a wave of her potent pheromones. Your [pc.cocksLight] immediately stiffen");
+		if(pc.cocks.length == 1) output("s");
+		if(!(pc.lowerUndergarment is EmptySlot)) output(" beneath your [pc.lowerUndergarment]. You strip off, eager to breed.");
+		else output(" in response, eager to breed.");
+	}
+	
+	output("\n\nHungry for her taste, you lean forward and bury your face between her sloppy folds, lapping at her wetness with your tongue. As she shivers and whinnies, you feel her exquisitely sweet, tangy taste roll across your tastebuds—she's so intoxicating! You bury your nose further, deeper, hungry for her centaur juice. Even as it gushes out and excitedly floods all over your cheeks and chin, you can't get enough!");
+	
+	if(ainaIsVirgin()) output("\n\n“I've never had someone's face down there~!” the inexperienced centauress gasps, her equine tail swishing wildly about.");
+	else output("\n\n“Th-that feels so good~!” the deflowered centauress gasps, her mare tail swishing wildly about.");
+	
+	output(" Not only is her potent pussy juice streaming down your chin and ");
+	
+	if(!pc.hasBreasts()) output(" chest");
+	else output(" between your breasts");
+	
+	output(", it's loudly splattering on the floor between her animal flanks. So wet! As you're hit with another wave of her musky mare snatch, your");
+	
+	if(pc.cocks.length > 1) output(" cocks achingly slap");
+	else output(" cock achingly slaps");
+	
+	output(" against your lower belly; all you can think about is mating and filling her belly with your [pc.cumVisc] [pc.cumNoun]!");
+	
+	output("\n\nGrabbing your [pc.biggestCock], you line it up with her silky black cunt lips, then give a forceful thrust.");
+	
+	if(ainaIsVirgin()) output(" There's a slight resistance, then a sudden give, and the virgin centauress gives a tiny squeal. As you slide into her unsullied depths, she gives a shivering moan, taking her very first cock! ");
+	else output(" Aina's cunt is so wet, warm, and welcoming!");
+	
+	output(" You're completely engulfed inside of her in no time at all. Her body-temperature is much higher than a human's; it feels like you're going to melt just being sheathed inside her flaring mare snatch.");
+	
+	if(ainaIsVirgin()) output("\n\n“S-so this is what a " + pc.mf("man", "dick") + " feels like?”");
+	else output("\n\n“I-I can't believe I used to use a toy!”");
+	
+	output(" Aina breathily gasps. She presses herself back against you, needily and insistently, her sizable rump rubbing against your lower half. Linked by your [pc.cocksLight], streams of her pussy-juice run out of her honeypot. With each slapping thrust of your hips, there's a lewd squelching noise, and even more of her musky wetness dribbles down between her quaking thighs. You grab onto her swishing horse-tail, using it to hold on against her bucking thrusts. This lusty centauress is quite the ride!");
+	output("\n\nAs you slap against her equine ass, you look up to see Aina breathily stripping off her modest sweater and bra and tossing them aside. With obvious inexperience, she fondles her now-naked breasts, pinching at her pointed peaks. You grin and slap your hips against her lower half—pressing your cockhead deeper inside her sloppy quim—and she lets out a sweet-lipped cry. Her fondling becomes rougher and needier, giving you a delightful show as you thoroughly fuck her, twitching tail in hand!");
+	output("\n\nWhen she cums, she lets out a loud whinny and her slippery cunt clamps down HARD on your cock, a series of muscular rings squeezing your length from your [pc.knot] to your crown. As she whimpers and trembles, hot girl-juice sprays your pulsing head from inside her sloppy honeypot. The pleasurable pressure bastes and batters your twitching tip, setting you off in turn. With a final primal thrust, you shoot your [pc.cumVisc] sperm into her equine womb,");
+	
+	if(pc.cumQ() < 100) output(" lightly bathing her eggs in your spurting seed.");
+	else if(pc.cumQ() < 4000) output(" filling it to the brim with your [pc.cumColor] seed.");
+	else output(" overfilling it with your [pc.cumColor] seed until the centauress's belly looks expectant with foals!");
+	
+	if(!pc.hasKnot(x)) 
+	{
+		output("\n\nAs you shoot your [pc.cumNoun] inside of her, some of it mixes with her sloppy mare juices drooling down from her flanks. You both make an utter mess of the floor beneath you, the results of mating with the cute centauress. When you finally pull out, there's a loud 'plop', and an even larger stream of sexual fluids leaks out from her dusky mare snatch. Aina lets out a dreamy sigh and turns around, hand stroking through her hair, another clasped modestly in front of her sweat-soaked breasts.");
+	}
+	else 
+	{
+		output("\n\nThe longer you cum, the more your knot swells inside her copious cunt, until your delving dick is locked in place. The swelling pins in both her cum and yours, pooling inside of her");
+		if(pc.cumQ() >= 4000) output(", increasing the inch-size of her already obscenely bloated belly!");
+		else output(" until her belly is so swollen it looks like she's expecting foals!");
+		
+		output("\n\n“Y-you're so big, and all swollen—!” Aina whimpers, her hoofs stomping at the ground. As you continuously cum inside her, trembling against her massive rump, the pressure causes her to climax, which in turn causes even more pressing inside her animal pussy! By the time your knot begins to deflate, she's a drooling, gibbering mess of pleasure. When you pull out, there's a loud 'plop', and a gushing stream of [pc.cumNoun] and girl-spunk floods out from between her flaring black pussylips, splashing wetly all over you and the floor!");
+		output("\n\nAfter such intense mating with the honey-haired mare, she collapses to the carpet, still moaning and twitching in the aftermath of delight.");
+		
+		if(pc.isNice()) output(" You help get her at least to the couch, then throw a blanket on her.");
+		else if(pc.isMischievous()) output(" You wince and grab a blanket, throwing it over her to at least keep her warm.");
+		else output(" Talk about a well-mated bitch...");
+	}
+	
+	if(ainaIsVirgin()) 
+	{
+		output("\n\n“M-my first time... I never knew proper mating could be so amazing,” Aina blushes, absentmindedly tucking a messed-up lock behind her ear. “I, um, I'm still feeling kind of lightheaded. Kind of floaty, even. I think maybe I should sit down? Oh, the mess! Did I really leak out that much?!”");
+		output("\n\nLooking thoroughly embarrassed, the centauress grabs a vacuu-mop. “Um, thank you so much. I really needed that. I-If you're ever in the Res Deck again, maybe look me up? I'd be more than willing to fit you in... um, I mean have you over!”");
+		output("\n\nYou grin and grab your things, leaving Aina to clean up. Given how wet she was, you imagine it's going to take quite a while.");
+	} 
+	else
+	{
+	output("\n\n“That was amazing... just like last time...” Aina blushes, absentmindedly tucking a messed-up lock behind her ear. “Um, you know, if you're ever in Res Deck again, feel free to call around. I always love having you over... whether we're talking or, you know, doing other things...”");
+	output("\n\nYou nod and grab your things. Your whole body reeks of mare musk! You're pretty sure anyone within a mile could smell it. You ask Aina if you can use her shower, and she nods enthusiastically.");
+	output("\n\n“Sure! Just on the right.”");
+	output("\n\nAfter using her shower to clean off, you let out a happy sigh, ruffling a towel over your [pc.hair]. You're feeling refreshed in so many ways!");
+	}
+	
+	ainaSexed(1);
+	
+	pc.orgasm();
+	processTime(20 + rand(15));
+	
+	clearMenu();
+	addButton(0, "Next", ainaMenu);
+}
+
+public function ainaSexedFisting():void
+{
+	clearOutput();
+	showAina();
+	
+	if(ainaIsInHeat()) output("You suggest a 'hands-on' approach to relieving her tensions,");
+	else output("You tell her that you're actually in the mood for something <i>else</i>,");
+	
+	if(pc.isChestGarbed()) output(" stripping off your [pc.uppergarments] and");
+	
+	output(" striding up behind her lovely, large rump. Reaching out, you hold your hand in front of her dusky equine slit. Her radiant warmth warms your palm, particularly with each whumphing flare of her");
+
+	if(ainaIsInHeat()) output(" moist");
+	else output(" velvety");
+	
+	output(" hind-lips.");
+	output("\n\n“O-oh, what um, <i>exactly</i> did you have in mind?” the honey-blonde centauress asks. She blushingly glances over her shoulder, straining to see what you're going to do with her rump.");
+	output("\n\nYou grin and slide your hand down and out of her sight. Slowly and sensually, you trail your fingertips up her lush lower lips. Aina trembles against your tracing hand, her horse-tail excitedly swishing about. Reaching down, you pointedly rub her thumb-sized clit. As soon as you do, her front knees buckle, and she presses her human-half against the couch, her gigantic equine butt in the air. Her flanks are trembling, and she's whinnying in delight.");
+	output("\n\n“So, you like that?” you ask, rubbing her womanly bud. It's a rhetorical question; streams of slippery mare juice are drooling out of her swollen black-lipped sex, wetting the ground beneath her quaking thighs.");
+	output("\n\n“Y-yes!” Aina whimpers, needily pressing her pussy back against your caressing fingers. You up the ante, sliding your fingers into her sloppy slit. There's so little resistance that your whole <i>hand</i> is quickly swallowed up inside of her. God, she's so fiercely hot and wet inside! Not only that, her walls are velvety soft and welcoming. They tease your trapped digits with their slippery soft feel, squeezing them with relish.");
+	output("\n\nIf she thinks that feels good, the centauress has seen nothing yet. Making a fist, you thrust your whole arm inside of her");
+	
+	if(ainaIsVirgin()) output(". There's a slight resistance, then a sudden give, and the virgin centauress gives a tiny squeal. As you slide into her unsullied depths right up to the elbow she gives a shivering moan, her cherry now taken!");
+	else output(" right up to the elbow.");
+	
+	output(" She whinnies with delight as you rigorously piston her with it like a stallion's cock. Sloppy wetness streams out from her pummeled pussy, providing more than enough lubricant for her fisting, and allowing you to get all the way inside her up to your shoulder. Stretching out your fingers, you tentatively caress her cervix, and she quakes and quivers in delight.");
+	output("\n\n“Whuh-what is that?! I-I feel—!” She doesn't finish her sentence, instead abruptly cumming all over you! Streams of sloppy girl-spunk spray out all over your [pc.chest] and [pc.face]. Your arm is clenched and trapped as you're utterly showered in her transparent lady juice. When she finally lets go, you're soaked from head to toe, utterly reeking like a musky mare!");
+
+	if(ainaIsVirgin())
+	{
+		output("\n\n“M-my first time... I never knew proper mating could be so amazing,” Aina blushes, absentmindedly tucking a messed-up lock behind her ear. “I, um, I'm still feeling kind of lightheaded. Kind of floaty, even. Oh, the mess! Did I really leak out that much? Maybe you should use my shower to clean off. It's on the right.”");
+		output("\n\nTaking her up on the offer, you duck into her shower, cleaning all her fem-cum off. It takes a while! After you get out, Aina approaches you, looking thoroughly embarrassed.");
+		output("\n\n“Um, thank you so much. I really needed that. I-If you're ever in the Res Deck again, maybe look me up? I'd be more than willing to fit you in... um, I mean have you over!”");
+	}
+	else{
+		output("\n\nWhen she's caught her breath, Aina turns around, her pale cheeks burning red. “Um, sorry. I got you a bit wet, didn't I? Maybe you should use my shower to clean off? It's on the right.”");
+		output("\n\nAfter using her shower to clean off, you let out a happy sigh, ruffling a towel over your [pc.hair]. You're feeling refreshed in so many ways!");
+	}
+	
+	ainaSexed(1);
+	processTime(20 + rand(15));
+	
+	clearMenu();
+	addButton(0, "Next", ainaMenu);
+}
+
+public function ainaSexedWithAnalWand():void
+{
+	clearOutput();
+	showAina();
+	
+	output("Knowing that Aina likes sex toys, you offer to use them on her since she has trouble using them on herself. The blonde centauress blushes and squirms at your suggestion, but she doesn't look unhappy.");
+
+	if(flags["AINA_SEXED_WITH_TOY"] == undefined) output("\n\n“Really, you'd do that for me? I'd love that");
+	else output("\n\n“I'd love to fool around again. You're way better with my toys than I am");
+	
+	output(",” Aina exclaims, a little breathy with excitement.");
+	
+	output("\n\nYou both head to the bedroom, where she slips off her champagne-colored sweater. Her creamy breasts spring out and bounce a little; seems she's not wearing a bra today! Her nipples are already stiff and puckered with excitement and her cute pink areolae are lightly crinkled. She clasps her hands down at her horse half. She inadvertently presses her slender arms against the sides of her breasts, pressing her well-rounded swells up and together in the process. You could throw a credit down that cleavage!");
+	output("\n\nYou don't get to enjoy the sight for nearly long enough, as Aina trots over to her special drawer and pulls out a number of toys. She places them one by one on the bed, then steps back, tucking back a blonde bang with a shy look.");
+	output("\n\n“So these are the toys you want to use?” You ask, picking up the biggest object there; a translucent, eighteen inch horse-cock. It jiggles in your hand, but squeezing it you realise it's actually got a lot of girth. Aina blushes and nods, squirming visibly on the spot.");
+	output("\n\n“Yes. Those are the ones I really want.” She's breathing a little heavily and her back-hoofs are trying not to stomp. You gesture for her to turn around and she obediently does so, backing back her chestnut colored rump. Her black-lipped horse sex is already dripping wet and gushing down her thighs. With her slick sex so close, you're hit with a fresh wave of her musky scent. It's a dizzying scent, one that you're quickly intoxicated by!");
+
+	if(pc.hasCock())
+	{
+		output(" Your [pc.cocks] immediately stiffen");
+		if (pc.cocks.length == 1) output("s");
+		output(" as you go into instant rut");
+		
+		if (pc.isTaur()) output(" as your equine instincts are stirred by the unmistakable scent of a needy mare");
+		else output(", even though you're not a centaur!");
+	}
+	else if(pc.hasVagina())
+	{
+		output(" Stimulated by her musk, your own [pc.pussies] quickly slicken");
+		if(pc.vaginas.length == 1) output("s");
+		output(" to match her own. As you wriggle your hips with delight, there's a palpable squelching noise down below; she's got you this wet this quickly?!");
+	}
+	
+	output("\n\nShaking your head in an effort to think straight, you grab the synthetic stallion prick and begin coating it in slick, sticky lube. With burning cheeks, you press the tip of the flat-headed horse-cock against her doughnut-like anus, which pokes out from between her buttocks in a thick ring. It takes some effort to press it into her muscular sphincter, but once the saucer-like crown makes it in, it suddenly slides inside with no give! You almost stumble forward but manage to keep standing as she takes several inches all at once. The blonde centauress lets out a whinnying gasp and her front legs buckle, her massive equine rump still raised and half-filled with transparent horse-cock! You can see every detail of her rippled rectum wrapping around the thick yet transparent phallus, showing off the insides of her pink butthole in all its lewd glory. It's surprisingly clean inside her ass! Her flaring pussy gets even wetter, spilling streams of musky girl-juice between her hind legs and splattering all over the floor.");
+	output("\n\n“Is it all in yet?” She breathily asks, golden-hair loosened and pressed down towards the ground. Her swishing mare-tail is still lifted up with her rump, seductively impaled with the phallic protrusion. You shake your head and push in a few more inches, delighting in the very visible sight of the flat horse-head sinking further and further into the depths of her twitching rectum. The more you push, the sloppier and wetter her equine pussy gets, spilling everywhere as you finally bottom the eighteen-inch toy inside of her with a loud <i>plop</i>. Impossibly full with such a long, thick length of stallion cock, the honey-haired mare whinnies and wrings the toy's entire length, her doughnut-like sphincter squeezing and stretching its base. She's going at it so hard that you're sure any man would have blown in her ass by now; as it is, the flexing toy is barely holding out!");
+	output("\n\nYou pick up one of her magic wands and click it on, feeling it whir and buzz in your hand. You press the toy's vibrating apple-sized head against her musky mare-sex and stroke it back and forth. Aina moans lewdly and rubs her juicy horse-snatch against the whirring tool in your hands. She's melting and bucking back with animalistic need, the air almost steamy with her pussy warmth. You grab her horse-tail and lustily rub the quaking wand against her bulbous black clit and the chestnut centauress lets out a pleasured squeal. You can see the clenching of her inner ass through the translucent toy packing her mare pucker, lewdly milking the stallion length as if it were a real cock stuffed in her hindquarters!");
+	output("\n\n“Naughty girl, wringing that cock so well in your ass,” you tease her, all the while stroking her dripping and flaring gash back and forth, and pressing against her clit. Aina's whinnying with delight, front legs completely buckled, hind quarters raised, and her anus erotically squeezing the stallion-length toy. Drops of her hot mare juice splatter down the wand and down your arm. You're lust-drunk on both her mare musk and you begin aggressively whizzing the toy along her slit like you're fucking her with it, your other fist full of twitching tail. The centauress whines and bucks back against you, fucking you right back!");
+	output("\n\n“I'm, I'm going to cum~!” Aina squeals a few seconds before it happens. With quaking hind-legs, her sloppy slit flares and you're utterly basted in thick gushes of her potent pussy juice, soaking you in her fragrant scent. As she splatters you in her girl-spunk, her doughnut-like anus clenches her butt-toy so hard it distorts in her rectum, warping in shape! Meanwhile your [pc.hips] shake uncontrollably as her intoxicating musk seizes your senses and sets off a full-body orgasm in");
+	
+	if(!(pc.lowerUndergarment is EmptySlot)) output(" your [pc.lowerUndergarment]");
+	else output("your nethers");
+	
+	output(", making you");
+	
+	if(pc.hasCock() && !pc.hasVagina()) output(" shoot your spunk");
+	if(pc.hasCock() && pc.hasVagina()) output(" and");
+	if(!pc.hasCock() && pc.hasVagina()) output(" splatter your nether lips with your girl juice");
+	if(!pc.hasCock() && !pc.hasVagina()) output(" quake with delight");
+	
+	output(". Your equine lover twitches and then collapses in a sweaty mess. Thankfully she falls forward, so she doesn't land on you!");
+	
+	output("\n\n“That was amazing.");
+	if(flags["AINA_SEXED_WITH_TOY"] == undefined) output(" “You're so much better with my toys than I am");
+	else output(" “You're amazing");
+	
+	output(",” Aina blushes, tucking back her thoroughly messed up locks. It takes you both some time before you're able to stand. Sniffing yourself, you realize your whole body reeks of mare musk! You're pretty sure anyone within a mile could smell it. You ask Aina if you can use her shower, and she nods enthusiastically.");
+	output("\n\n“Sure! Just on the right.”");
+	output("\n\nAfter using her shower to clean off, you let out a happy sigh, ruffling a towel over your [pc.hair]. You're feeling refreshed in so many ways!");
+
+	ainaSexed(1);
+	flags["AINA_SEXED_WITH_TOY"] = true;
+	
+	pc.orgasm();
+	processTime(20 + rand(15));
+	
+	clearMenu();
+	addButton(0, "Next", ainaMenu);
+}

--- a/includes/tavros/fyn.as
+++ b/includes/tavros/fyn.as
@@ -299,24 +299,39 @@ public function fynTalk():void {
 	
 	output("What do you want to talk about?");
 	
+	fynTalkNavigation();
+}
+
+public function fynTalkNavigation(activeTopic:Function = undefined):void {
 	clearMenu();
-	addButton(0, "Fyn", fynTalksAboutFyn);
-	//unlocked after talked about Fyn
-	if(flags["FYN_TALKED_ABOUT_FYN"]) addButton(1, "Hobbies", fynTalksAboutHobbies); 
+	
+	if(activeTopic == fynTalksAboutFyn) addDisabledButton(0, "Fyn", "Fyn", "You just spoke about that.");
+	else addButton(0, "Fyn", fynTalksAboutFyn, undefined, "Fyn", "Ask Fyn about himself.");
+	
+	if(activeTopic == fynTalksAboutHobbies) addDisabledButton(1, "Hobbies", "Hobbies", "You just spoke about that.");
+	else if(flags["FYN_TALKED_ABOUT_FYN"]) addButton(1, "Hobbies", fynTalksAboutHobbies, undefined, "Hobbies", "Ask Fyn about his hobbies."); 
 	else addDisabledButton(1, "Hobbies", "Hobbies", "You don't know him well enough to talk about that.");
-	//unlocked after talked about hobbies + relationship 1+
-	if(flags["FYN_TALKED_ABOUT_HOBBIES"] && fynRelationshipStatus() >= 1) addButton(2, "Sex", fynTalksAboutSex);
+	
+	if(activeTopic == fynTalksAboutSex) addDisabledButton(2, "Sex", "Sex", "You just spoke about that.");
+	else if(flags["FYN_TALKED_ABOUT_HOBBIES"] && fynRelationshipStatus() >= 1) addButton(2, "Sex", fynTalksAboutSex, undefined, "Ask Fyn about his sexual interests.");
 	else if (flags["FYN_TALKED_ABOUT_HOBBIES"] == undefined) addDisabledButton(2, "Sex", "Sex", "You don't know him well enough to talk about that.");
 	else addDisabledButton(2, "Sex", "Sex", "Fyn has no interest in talking about sex with you."); //pc did not firt and blocked sex menu
-	addButton(3, "Vildarii", fynTalksAboutVildarii);
-	addButton(4, "Career", fynTalksAboutCareer);
-	addButton(5, "Dancing", fynTalksAboutDancing);
-	//unlocked after talked about Fyn
-	if(flags["FYN_TALKED_ABOUT_FYN"]) addButton(6, "Singing", fynTalksAboutSinging); 
+	
+	if(activeTopic == fynTalksAboutVildarii) addDisabledButton(3, "Vildarii", "Vildarii", "You just spoke about that.");
+	else addButton(3, "Vildarii", fynTalksAboutVildarii, undefined, "Vildarii", "Ask Fyn about his race.");
+	if(activeTopic == fynTalksAboutCareer) addDisabledButton(4, "Career", "Career", "You just spoke about that.");
+	else addButton(4, "Career", fynTalksAboutCareer, undefined, "Career", "Ask Fyn about his career.");
+	if(activeTopic == fynTalksAboutDancing) addDisabledButton(5, "Dancing", "Dancing", "You just spoke about that.");
+	else addButton(5, "Dancing", fynTalksAboutDancing, undefined, "Dancing", "Ask Fyn about dancing.");
+	
+	if(activeTopic == fynTalksAboutSinging) addDisabledButton(6, "Singing", "Singing", "You just spoke about that.");
+	else if(flags["FYN_TALKED_ABOUT_FYN"]) addButton(6, "Singing", fynTalksAboutSinging, undefined, "Singing", "Ask Fyn about singing."); 
 	else addDisabledButton(6, "Singing", "Singing", "You don't know him well enough to talk about that.");
-	//unlocked after talked about hobbies
-	if(flags["FYN_TALKED_ABOUT_HOBBIES"]) addButton(7, "Fencing", fynTalksAboutFencing);
+	
+	if(activeTopic == fynTalksAboutFencing) addDisabledButton(7, "Fencing", "Fencing", "You just spoke about that.");
+	else if(flags["FYN_TALKED_ABOUT_HOBBIES"]) addButton(7, "Fencing", fynTalksAboutFencing, undefined, "Fencing", "Ask Fyn about fencing.");
 	else addDisabledButton(7, "Fencing", "Fencing", "You don't know him well enough to talk about that.");
+	
 	addButton(14, "Back", fynMenu);
 }
 
@@ -341,7 +356,7 @@ public function fynTalksAboutFyn():void {
 		
 		fynTalksAboutFynPartTwo();
 		
-		addButton(14, "Back", fynTalk);
+		fynTalkNavigation(fynTalksAboutFyn);
 	}
 }
 
@@ -399,8 +414,7 @@ public function fynTalksAboutFynPcFlirts():void {
 	
 	processTime(10 + rand(5));
 	
-	clearMenu();
-	addButton(14, "Back", fynTalk);
+	fynTalkNavigation(fynTalksAboutFyn);
 }
 
 public function fynTalksAboutFynPcPlaysHardToGet():void {
@@ -422,8 +436,7 @@ public function fynTalksAboutFynPcPlaysHardToGet():void {
 	
 	processTime(2);
 	
-	clearMenu();
-	addButton(14, "Back", fynTalk);
+	fynTalkNavigation(fynTalksAboutFyn);
 }
 
 public function fynTalksAboutFynPcIsNoFlirt():void {
@@ -442,8 +455,7 @@ public function fynTalksAboutFynPcIsNoFlirt():void {
 	
 	processTime(2);
 	
-	clearMenu();
-	addButton(14, "Back", fynTalk);
+	fynTalkNavigation(fynTalksAboutFyn);
 }
 
 //the second part of Fyns flirt talk to be appended to all three possible answers
@@ -469,8 +481,7 @@ public function fynTalksAboutHobbies():void {
 	flags["FYN_TALKED_ABOUT_HOBBIES"] = true;
 	processTime(5 + rand(5));
 	
-	clearMenu();
-	addButton(14, "Back", fynTalk);
+	fynTalkNavigation(fynTalksAboutHobbies);
 }
 
 public function fynTalksAboutSex():void {
@@ -487,8 +498,7 @@ public function fynTalksAboutSex():void {
 	
 	processTime(5 + rand(5));
 	
-	clearMenu();
-	addButton(14, "Back", fynTalk);
+	fynTalkNavigation(fynTalksAboutSex);
 }
 
 public function fynTalksAboutVildarii():void {
@@ -509,8 +519,7 @@ public function fynTalksAboutVildarii():void {
 	
 	processTime(10 + rand(5));
 	
-	clearMenu();
-	addButton(14, "Back", fynTalk);
+	fynTalkNavigation(fynTalksAboutVildarii);
 }
 
 public function fynTalksAboutCareer():void {
@@ -524,8 +533,7 @@ public function fynTalksAboutCareer():void {
 	
 	processTime(10 + rand(5));
 	
-	clearMenu();
-	addButton(14, "Back", fynTalk);
+	fynTalkNavigation(fynTalksAboutCareer);
 }
 
 public function fynTalksAboutDancing():void {
@@ -544,8 +552,7 @@ public function fynTalksAboutDancing():void {
 	
 	processTime(10 + rand(5));
 	
-	clearMenu();
-	addButton(14, "Back", fynTalk);
+	fynTalkNavigation(fynTalksAboutDancing);
 }
 
 public function fynTalksAboutSinging():void {
@@ -574,8 +581,7 @@ public function fynTalksAboutSinging():void {
 	
 	processTime(10 + rand(5));
 	
-	clearMenu();
-	addButton(14, "Back", fynTalk);
+	fynTalkNavigation(fynTalksAboutSinging);
 }
 
 public function fynTalksAboutFencing():void {
@@ -592,8 +598,7 @@ public function fynTalksAboutFencing():void {
 	
 	processTime(10 + rand(5));
 	
-	clearMenu();
-	addButton(14, "Back", fynTalk);
+	fynTalkNavigation(fynTalksAboutFencing);
 }
 
 public function fynLessons():void {

--- a/includes/tavros/fyn.as
+++ b/includes/tavros/fyn.as
@@ -1,3 +1,5 @@
+import classes.StorageClass;
+
 //Available Flags
 
 //MET_FYN:						If the PC met Fyn (true or undefined)
@@ -679,9 +681,10 @@ public function fynTeachesDancing():void {
 			break;
 	}
 	
-	flags["FYN_TAUGHT_DANCING"] = true;
-	
 	processTime(30 + rand(10));
+	applyFynTeachingEffect("dancing");
+	
+	flags["FYN_TAUGHT_DANCING"] = true;
 	
 	clearMenu();
 	addButton(0, "Next", fynMenu);
@@ -734,6 +737,7 @@ public function fynTeachesStripping():void
 	}
 	
 	processTime(30 + rand(10));
+	applyFynTeachingEffect("stripping");
 	
 	clearMenu();
 	addButton(0, "Next", fynMenu);
@@ -781,9 +785,41 @@ public function fynTeachesFencing():void
 	}
 	
 	processTime(30 + rand(10));
+	applyFynTeachingEffect("fencing");
 	
 	clearMenu();
 	addButton(0, "Next", fynMenu);
+}
+
+//Apply non-stacking status effects based on the lesson taken. They last three days.
+public function applyFynTeachingEffect(lessonTaught:String = ""):void
+{
+	if(lessonTaught == "dancing" || lessonTaught == "stripping") 
+	{
+		if(!pc.hasStatusEffect("Sexy Moves")) 
+		{
+			pc.createStatusEffect("Sexy Moves",0,0,0,0,false,"OffenseUp","Your recent lessons pay off, you feel as sexy as ever — and it shows.",false,4320);
+		} 
+		else 
+		{
+			//reset duration to full length
+			var effect:StorageClass = pc.getStatusEffect("Sexy Moves");
+			effect.minutesLeft = 4320;
+		}
+	}
+	if(lessonTaught == "fencing") 
+	{
+		if(!pc.hasStatusEffect("Lightning Moves")) 
+		{
+			pc.createStatusEffect("Lightning Moves",0,0,0,0,false,"OffenseUp","Your recent fencing lessons give you an edge during fights.",false,4320);
+		} 
+		else 
+		{
+			//reset duration to full length
+			var effect:StorageClass = pc.getStatusEffect("Lightning Moves");
+			effect.minutesLeft = 4320;
+		}
+	}
 }
 
 public function fynSexMenu():void 

--- a/includes/tavros/fyn.as
+++ b/includes/tavros/fyn.as
@@ -61,6 +61,8 @@ public function playFynsDoorScene():void {
 	
 	output("Do you knock on the large oak door?");
 	
+	processTime(1);
+	
 	clearMenu();
 	addButton(0, "Yes", knockOnFynsDoor, undefined, "Knock", "Why not? You're kind of curious to see who lives inside... you only live once, right?");
 	addButton(1, "No", walkAwayFromFynsDoor, undefined, "Don't knock", "Just walk away. After all, what reason do you have to knock on some random's door?");
@@ -74,6 +76,8 @@ public function walkAwayFromFynsDoor():void {
 	
 	//throw player out on corridor
 	currentLocation = "RESIDENTIAL DECK 11";
+	
+	processTime(1);
 	
 	clearMenu();
 	addButton(0, "Next", mainGameMenu);
@@ -90,11 +94,15 @@ public function knockOnFynsDoor():void {
 		output("\n\n“So what are you waiting for? Come on inside, and let's get started.” The door is fully open now, and he's gesturing for you to go inside.");
 		output("\n\nFor some reason, standing this close to him, you can smell fresh male sweat. Has he been exercising? You can definitely see a slight sheen to his muscles.");
 		output("\n\nWhat do you do?");
+		
+		processTime(5);
 	}
 	else 
 	{
 		output("You knock on the door again, deciding to give it another try. Not long after you're finished knocking, the door swings half open and the same tall, shirtless man steps out. He quirks one of his distinctively dark brows, shooting you a curious, slightly amused look. “... Back again? I'm not a doorman, you know. And I <i>do</i> charge by the hour.”");
 		output("\n\n“So what are you waiting for? Come on inside, and let's get started.” The door is fully open now, and he's gesturing for you to go inside. What do you do?");
+	
+		processTime(2);
 	}
 	
 	flags["MET_FYN"] = true;
@@ -113,6 +121,8 @@ public function backOutOfGoingIntoFynsApartment():void {
 	else output("“Nope. Wrong door. See ya.” You wave and hastily walk off.");
 	
 	output(" The look of amusement doesn't leave the handsome crimson-skinned man's face, even as he slips back inside and closes the door. What was <i>that</i> all about?");
+	
+	processTime(2);
 	
 	//throw player out on corridor
 	currentLocation = "RESIDENTIAL DECK 11";
@@ -140,6 +150,8 @@ public function goIntoFynsApartment():void {
 	
 	output(". The devilish-looking man stretches out, absentmindedly baring his broad shoulders and chest. He looks perfectly at home without a shirt; but then again, he <i>is</i> home, isn't he?");
 	output("\n\n“... So, do you have a lot of experience, or is this first time?”");
+	
+	processTime(5);
 	
 	clearMenu();
 	addButton(0, "Lots", resolveFynConfusion, 'lots', "Lots", "Oh yeah, you've got, uh, *tons* of experience... in whatever it is that he's talking about. Bluff like a pro!");
@@ -219,6 +231,8 @@ public function resolveFynConfusion(type:String):void {
 	flags["FYN_APARTMENT_ENTERED"] = true;
 	CodexManager.unlockEntry("Vildarii");
 	
+	processTime(10 + rand(5));
+	
 	clearMenu();
 	addButton(0, "Next", mainGameMenu);
 }
@@ -253,6 +267,8 @@ public function fynMenu():void {
 			output("\n\n“Greetings! Just catching up on some light reading. Fascinating things those siel come up with. There's more knots in some of these bindings than an ausar orgy.”");
 			break;
 	}
+	
+	processTime(1);
 	
 	clearMenu();
 	addButton(0, "Appearance", fynAppearance);
@@ -302,8 +318,6 @@ public function fynTalk():void {
 	if(flags["FYN_TALKED_ABOUT_HOBBIES"]) addButton(7, "Fencing", fynTalksAboutFencing);
 	else addDisabledButton(7, "Fencing", "Fencing", "You don't know him well enough to talk about that.");
 	addButton(14, "Back", fynMenu);
-	
-	
 }
 
 public function fynTalksAboutFyn():void {
@@ -383,6 +397,8 @@ public function fynTalksAboutFynPcFlirts():void {
 	
 	fynTalksAboutFynPartTwo();
 	
+	processTime(10 + rand(5));
+	
 	clearMenu();
 	addButton(14, "Back", fynTalk);
 }
@@ -404,6 +420,8 @@ public function fynTalksAboutFynPcPlaysHardToGet():void {
 	
 	fynTalksAboutFynPartTwo();
 	
+	processTime(2);
+	
 	clearMenu();
 	addButton(14, "Back", fynTalk);
 }
@@ -422,6 +440,8 @@ public function fynTalksAboutFynPcIsNoFlirt():void {
 	
 	fynTalksAboutFynPartTwo();
 	
+	processTime(2);
+	
 	clearMenu();
 	addButton(14, "Back", fynTalk);
 }
@@ -432,6 +452,8 @@ public function fynTalksAboutFynPartTwo():void {
 	output("\n\n“My full name is Fyn Wilder; or at least, that's my full stage name. Apparently 'Eriladar' apparently wasn't distinctive enough, or too hard to pronounce, so my agent suggested I axe it,” he gives a light shrug, “'Fyn Wilder' seemed like a good fit.”");
 	output("\n\n“I'm twenty eight, and my home planet is Merope, in the Pleaides star cluster. That's not too far from terra, galaxy-wise, so we got a lot of terran culture growing up. I'm actually a bit of a terraphile, truth be told; some of the old earth cultures had some real character.”");
 	output("\n\n“Loving terran culture is probably what attracted to me to the stage,” the raven-haired man pointedly touches his throat, “Thankfully, my family had me genetically modified before I was born; my vocal cords are sliced with a fanfir's. It was all the rage with vildarii back then, and it really helped keep up with the competition.”");
+
+	processTime(5);
 }
 
 public function fynTalksAboutHobbies():void {
@@ -445,6 +467,7 @@ public function fynTalksAboutHobbies():void {
 	if(fynRelationshipStatus() >= 1) output("\n\nBondage? You picture yourself trussed up in of silk, put on display for Ryn's satisfaction. That's <i>one</i> way to get in his bedroom, apparently!");
 	
 	flags["FYN_TALKED_ABOUT_HOBBIES"] = true;
+	processTime(5 + rand(5));
 	
 	clearMenu();
 	addButton(14, "Back", fynTalk);
@@ -461,6 +484,8 @@ public function fynTalksAboutSex():void {
 	output("\n\nIt's a bit surprising to hear such a wild and wicked looking guy is actually somewhat monogamous. Or rather, he's into open relationships, for all his kinks.");
 	
 	flags["FYN_TALKED_ABOUT_SEX"] = true;
+	
+	processTime(5 + rand(5));
 	
 	clearMenu();
 	addButton(14, "Back", fynTalk);
@@ -482,6 +507,8 @@ public function fynTalksAboutVildarii():void {
 	output("\n\n“Well, I can change the overall texture, shape, and color of everything, really. Sprouting ausar ears or kaithrit whiskers, for example, or even an extra phallus should the mood suit me. On a good day, I can do a tail, but that's a <i>lot</i> of work.”");
 	output("\n\n“That said, it's not as easy as it looks. Every time I change, I need to binge eat like crazy; transforming burns up things like fats and sugars, so come performance time, I've got to chow down like my life depends on it. Not a bad deal, though, eating so much and never having it hit the hips.”");
 	
+	processTime(10 + rand(5));
+	
 	clearMenu();
 	addButton(14, "Back", fynTalk);
 }
@@ -494,6 +521,8 @@ public function fynTalksAboutCareer():void {
 	output("\n\n“Yeah. Well, I did make it big time. I was cast a big role with the Starlanders; that's a theatrical company that do holo-productions as well. I would have been broadcast large as life, all three dimensions across countless star systems...”");
 	output("\n\nFyn pauses and looks off into a random direction, furrowing his brow.”... And someone very close to me died. I didn't really have it in my heart to perform after that,” he pauses for a moment. “...It nearly killed my agent, but I decided to quit and come out here to the edges of Rush space.”");
 	output("\n\nYou ask him what he's looking for, out here on the edges of known space, and Fyn gives a somber smile. “Honestly? I don't know. All I knew is I wasn't going to find it back there in the core.”");
+	
+	processTime(10 + rand(5));
 	
 	clearMenu();
 	addButton(14, "Back", fynTalk);
@@ -512,6 +541,8 @@ public function fynTalksAboutDancing():void {
 	output("\n\n“When I do it, hun, it's an art. Trust me. Being able to make someone's practically flutter back into their head, just with how much you're winding them up? Forget art; that's practically <i>magic</i>.”");
 	
 	if(fynRelationshipStatus() >= 1) output("\n\nYou look down at Fyn's hips, imagining him giving you a hot strip tease... and suddenly you feel <i>yourself</i> swooning. He's not half wrong; that <i>would</i> be like magic.");
+	
+	processTime(10 + rand(5));
 	
 	clearMenu();
 	addButton(14, "Back", fynTalk);
@@ -541,6 +572,8 @@ public function fynTalksAboutSinging():void {
 	output("\n\nSo, does that mean Fyn can do what fanfir can do? The singer smiles and shakes his head.");
 	output("\n\n“Not to that degree. I mean, fanfir have massive throats. Even when they talk, it's truly captivating. My birthright only gives me a superior singing range.”");
 	
+	processTime(10 + rand(5));
+	
 	clearMenu();
 	addButton(14, "Back", fynTalk);
 }
@@ -556,6 +589,8 @@ public function fynTalksAboutFencing():void {
 	output("\n\nJust like everything he does, Fyn seems rather passionate about fencing, too. You could probably get you to teach him a few things about it. Maybe it'll help you out in rush space?");
 	
 	flags["FYN_TALKED_ABOUT_FENCING"] = true;
+	
+	processTime(10 + rand(5));
 	
 	clearMenu();
 	addButton(14, "Back", fynTalk);
@@ -641,6 +676,8 @@ public function fynTeachesDancing():void {
 	
 	flags["FYN_TAUGHT_DANCING"] = true;
 	
+	processTime(30 + rand(10));
+	
 	clearMenu();
 	addButton(0, "Next", fynMenu);
 }
@@ -691,6 +728,8 @@ public function fynTeachesStripping():void
 			break;
 	}
 	
+	processTime(30 + rand(10));
+	
 	clearMenu();
 	addButton(0, "Next", fynMenu);
 }
@@ -735,6 +774,8 @@ public function fynTeachesFencing():void
 			output("\n\nFyn feints against you for a while, leading by example and showing you some different kinds. You then practice what you've learned on him, trying to break through his defenses. Once the lesson is over, you feel like you're more astute than ever, and on top of your game.");
 			break;
 	}
+	
+	processTime(30 + rand(10));
 	
 	clearMenu();
 	addButton(0, "Next", fynMenu);

--- a/includes/tavros/fyn.as
+++ b/includes/tavros/fyn.as
@@ -816,8 +816,8 @@ public function applyFynTeachingEffect(lessonTaught:String = ""):void
 		else 
 		{
 			//reset duration to full length
-			var effect:StorageClass = pc.getStatusEffect("Lightning Moves");
-			effect.minutesLeft = 4320;
+			var effect2:StorageClass = pc.getStatusEffect("Lightning Moves");
+			effect2.minutesLeft = 4320;
 		}
 	}
 }

--- a/includes/tavros/fyn.as
+++ b/includes/tavros/fyn.as
@@ -1,0 +1,1188 @@
+//Available Flags
+
+//MET_FYN:						If the PC met Fyn (true or undefined)
+//FYN_APARTMENT_ENTERED:		If the PC entered Fyn's apartment in the past
+//FYN_RELATIONSHIP_STATUS:		What relationsip the PC an Fyn share - 0 acquaintances, 1 sex buddies, starts at 0
+//FYN_TALKED_ABOUT_FYN:			If the player talked with Fyn about ...Fyn (true or undefined)
+//FYN_TALKED_ABOUT_SEX:			If the player talked with Fyn about sex (true or undefined)
+//FYN_TALKED_ABOUT_HOBBIES:		If the player talked with Fyn about his hobbies (true or undefined)
+//FYN_TALKED_ABOUT_FENCING:		If the player talked with Fyn about fancing (true or undefined)
+//FYN_TALKED_ABOUT_SAVEWORDS:	If the player talked with Fyn about save words (true or undefined)
+//FYN_TAUGHT_DANCING:			If the player had dancing lessons (true or undefined)
+//FYN_SEXED:					Counts the time the pc had sex with fyn (int 1+ or undefined)
+//FYN_SEXED_DOUBLE_DICK:		If the player ever did Fyn's double dick scene (true or undefined)
+//FYN_SEXED_ORC_RAVISH:			Counts the time the player was ravished by an orc Fyn (undefined or 1+)
+
+
+//display fyn's name + author infos
+public function showFyn(nude:Boolean = false):void
+{
+	showName("\nFyn");
+	author("JimThermic");
+}
+
+//get the int value of Fyns relationship status
+public function fynRelationshipStatus():int 
+{
+	if(flags["FYN_RELATIONSHIP_STATUS"] == undefined) return 0;
+	else return flags["FYN_RELATIONSHIP_STATUS"];
+}
+
+//update Fyns relationship status. Current min value is 0, max value is 1
+public function fynAdjustRelationshipStatus(adjustment:int):void 
+{
+	if(flags["FYN_RELATIONSHIP_STATUS"] == undefined) flags["FYN_RELATIONSHIP_STATUS"] = 0;
+	
+	flags["FYN_RELATIONSHIP_STATUS"] += adjustment;
+	
+	if(flags["FYN_RELATIONSHIP_STATUS"] > 1) flags["FYN_RELATIONSHIP_STATUS"] = 1;
+	else if(flags["FYN_RELATIONSHIP_STATUS"] < 0) flags["FYN_RELATIONSHIP_STATUS"] = 0;
+}
+
+//increase the amount fyn was sexed by x
+public function fynSexed(times:int):void {
+	if (flags["FYN_SEXED"] == undefined) flags["FYN_SEXED"] = 0;
+	flags["FYN_SEXED"] += times;
+}
+
+public function checkFynDoorScene():void {
+	if(flags["FYN_APARTMENT_ENTERED"] == true) 
+	{
+		showFynsApartment();
+	} 
+	else {
+		playFynsDoorScene();
+	}
+}
+
+public function playFynsDoorScene():void {
+	clearOutput();
+	showFyn();
+	
+	output("Do you knock on the large oak door?");
+	
+	clearMenu();
+	addButton(0, "Yes", knockOnFynsDoor, undefined, "Knock", "Why not? You're kind of curious to see who lives inside... you only live once, right?");
+	addButton(1, "No", walkAwayFromFynsDoor, undefined, "Don't knock", "Just walk away. After all, what reason do you have to knock on some random's door?");
+}
+
+public function walkAwayFromFynsDoor():void {
+	clearOutput();
+	showFyn();
+	
+	output("Deciding to not bother whoever lives here, you step back from the door. Who lives inside is just one more mystery in the universe left unsolved.");
+	
+	//throw player out on corridor
+	currentLocation = "RESIDENTIAL DECK 11";
+	
+	clearMenu();
+	addButton(0, "Next", mainGameMenu);
+}
+
+public function knockOnFynsDoor():void {
+	clearOutput();
+	showFyn();
+	
+	if(flags["MET_FYN"] == undefined) {
+		output("You decide to give in to your curiosity and rap your knuckles against the sturdy wooden door. Is it real oak, you wonder?");
+		output("\n\nJust as you don't think anyone's going to answer, the door swings half open and a tall, shirtless man steps out. He quirks one of his distinctively dark brows, shooting you a curious, slightly amused look. “... Well, you took your time.”");
+		output("\n\nWow. Looking at this guy is like looking at a work of art. Even though he's clearly not human—the vermillion skin and pointed ears are a dead give away—his well-sculptured figure is distinctly terran in shape. His eyes are full of fire; passionate burning orbs with black, tiger-like slits.");
+		output("\n\n“So what are you waiting for? Come on inside, and let's get started.” The door is fully open now, and he's gesturing for you to go inside.");
+		output("\n\nFor some reason, standing this close to him, you can smell fresh male sweat. Has he been exercising? You can definitely see a slight sheen to his muscles.");
+		output("\n\nWhat do you do?");
+	}
+	else 
+	{
+		output("You knock on the door again, deciding to give it another try. Not long after you're finished knocking, the door swings half open and the same tall, shirtless man steps out. He quirks one of his distinctively dark brows, shooting you a curious, slightly amused look. “... Back again? I'm not a doorman, you know. And I <i>do</i> charge by the hour.”");
+		output("\n\n“So what are you waiting for? Come on inside, and let's get started.” The door is fully open now, and he's gesturing for you to go inside. What do you do?");
+	}
+	
+	flags["MET_FYN"] = true;
+	
+	clearMenu();
+	addButton(0, "GoIn", goIntoFynsApartment, undefined, "Go in", "Why not see where this goes? Could be kind of fun.");
+	addButton(1, "Nope!", backOutOfGoingIntoFynsApartment, undefined, "Don't go in", "Time to back out of here. He's clearly mistaken you for someone else!");
+}
+
+public function backOutOfGoingIntoFynsApartment():void {
+	clearOutput();
+	showFyn();
+	
+	if(pc.isNice()) output("Apologising for wasting his time, you quickly back off and take your leave.");
+	else if(pc.isMischievous()) output("“Sorry, wrong apartment. Thanks for your time!” you exclaim, taking your leave.");
+	else output("“Nope. Wrong door. See ya.” You wave and hastily walk off.");
+	
+	output(" The look of amusement doesn't leave the handsome crimson-skinned man's face, even as he slips back inside and closes the door. What was <i>that</i> all about?");
+	
+	//throw player out on corridor
+	currentLocation = "RESIDENTIAL DECK 11";
+	
+	clearMenu();
+	addButton(0, "Next", mainGameMenu);
+}
+
+public function goIntoFynsApartment():void {
+	clearOutput();
+	showFyn();
+	
+	output("You go with the flow, stepping through the threshold. The door closes soundly behind you. The tall, shirtless man strides past you and through the apartment. Does he expect you to follow?");
+	output("\n\nYou follow in his footsteps through the huge, luxurious apartment, reeling a little at the amount of credits it must have cost. From the polished synth-oak floors to the artwork pieces, there's definitely a glamorous air to the place. Whoever he is, he's definitely wealthy, there's no doubt about that. Spotting an open doorway, you see the beginnings of a bedroom, replete with a silky, king sized bed. It's not hard to see the silk ropes tied to the foot of the bed... it's not hard to guess what <i>they</i> would be for.");
+	output("\n\nYou're not lead there, though, but rather to a circular island-like kitchen in the common area, surrounded by an abundance of seating. Your host turns to you and runs a hand through his long, midnight-black hair. “...Would you like a drink? We're pretty well stocked here.”");
+
+	output("\n\nYou");
+	if(pc.isNice()) output(" politely");
+	else if(pc.isMischievous()) output(" jovially");
+	else output("brusquely");
+	
+	output(" accept, and he fetches you both a drink, sitting down on one of the comfy-looking curved sofas. You sit opposite from him");
+	
+	if (pc.isTaur()) output(", crouching down with your tauric body/sinking into the cushions");
+	
+	output(". The devilish-looking man stretches out, absentmindedly baring his broad shoulders and chest. He looks perfectly at home without a shirt; but then again, he <i>is</i> home, isn't he?");
+	output("\n\n“... So, do you have a lot of experience, or is this first time?”");
+	
+	clearMenu();
+	addButton(0, "Lots", resolveFynConfusion, 'lots', "Lots", "Oh yeah, you've got, uh, *tons* of experience... in whatever it is that he's talking about. Bluff like a pro!");
+	addButton(1, "None", resolveFynConfusion, 'none', "None", "No experience whatsoever in whatever he's talking about, probably.");
+	addButton(2, "ComeClean", resolveFynConfusion, 'come_clean', "Come clean", "Just tell him you have no idea what's going on, and you just knocked on the door out of curiosity. Come clean!");
+}
+
+//come clean and tell fyn you have no idea what he is talking about
+public function resolveFynConfusion(type:String):void {
+	clearOutput();
+	showFyn();
+	
+	switch(type) {
+		case 'come_clean' :
+			output("You figure it's time to come clean, and admit that you have <i>no</i> idea what's going on. His powerful brows raise in sudden comprehension, his whole face soon following suit.");
+			output("\n\n“Ah. So you knocked on the door, and then I assumed...” Instead of looking upset, however, he looks deeply amused.");
+			break;
+		case 'lots' :
+			output("“Interesting. It'll be good to do it with someone who can keep up,” the dark-haired man smiles. He crooks a finger and touches his chin, looking at you with an intense and thoroughly <i>interested</i> gaze.");
+			
+			break;
+		case 'none' :
+			output("“Oh, so I'll be your first? That's quite a responsibility,” the dark-haired man smiles, a glint in his eyes. His intense brows are raised; he suddenly looks <i>very</i> interested in you.");
+			break;
+	}
+	
+	if(type == 'lots' || type == 'none') {
+		output("\n\n“...How about we just do it here and now, then?” he offers, his baritone voice lowering to a distinctively sensual note. Hopping off the couch, he then confidently strides up to you, taking your hand and pointedly pulling you upright! You find yourself pressed against his superbly well formed chest");
+		
+		if(pc.tallness < 60 || pc.tallness < 84) output(", his narrow waist pressing against yours");
+		output(".");
+		output(" You gasp; is he rubbing <i>that</i> against");
+		if(pc.hasCock()) output(" <i>yours</i>");
+		else output(" you");
+		output(" on purpose?");
+		
+		output("\n\n“What, right here, in the living room?”");
+		output("\n\n“Of course. No need to make a big song and dance about it. After all, it's not your first time, so the living room should be fine...” He grabs your hand in his, firmly grasping it, bringing his symmetrical face closer to yours. His body smell is masculine and fresh. “...Are you ready?”");
+		output("\n\nYou nod, a hand reaching up to tentatively run through his dark, long hair. It's so soft and shiny, almost criminally so, the sort that you could run your hands through for hours. “... Yes. Let's do it.”");
+		output("\n\nAt that moment, he pauses, looking deep into your eyes. His powerful brows then raise in sudden comprehension, his whole expression following suit. “... Ah. You... have no idea what I'm talking about, do you?”");
+		output("\n\nYou shake your head, and he pulls back a little. Rather than bothered, he looks distinctly amused. “You just walked up and knocked on my door, didn't you? And then I assumed...”");
+		output("\n\n“Yup.”");
+	}
+	
+	output("\n\n“... Right. So, perhaps introductions, then?”");
+	output("\n\n“Seems like a good place to start,”");
+	
+	if(pc.isNice()) output(" you warmly answer.");
+	else if(pc.isMischievous()) output(" you grin. It <i>was</i> pretty fun to lead him on like that.");
+	else output("you bluntly respond.");
+	
+	output("\n\n“I'm Fyn Wilder. Honestly, I thought you were here for some private dancing lessons. Samba, belly dancing, strip-tease, that sort of thing..”");
+	output("\n\nFyn Wilder... Fyn Wilder... wait, you've heard that name before. Something in the recent holos, about a young, talented performer... but his face looks different from the images you've seen. When you question him about it, he gives a rich laugh.");
+	output("\n\n“That's me. Though I very rarely go onto the stage with this face. Not unless I'm playing the terran devil, anyway. Usually something a little more like this...” Fyn then waves a hand dramatically in front of his face. There's a sudden shift, and you're left gaping at a terran-looking man with surprisingly brown hair and facial stubble.");
+	
+	output("\n\n“... You're");
+	if(CodexManager.entryUnlocked("Vildarii")) output(" a vildarii");
+	else output(" a polymorph");
+	output("!” you exclaim in stunned surprise. His dark eyes are glinting with amusement, relishing in your reaction. A true performer, through and through.");
+	
+	output("\n\n“Of course;");
+	if(CodexManager.entryUnlocked("Vildarii")) output(" vildarii");
+	else output(" we polymorphs");
+	output(" are natural performers. Some better than others, of course,” he adds, with no small hint of pride. “Anyway, my cards are on the table. How about yours? You never told me your name.”");
+	
+	output("\n\n“[pc.name] Steele,” you tell him. Fyn's eyes definitely light up. After all, he's not the only famous one in the room.");
+	output("\n\n“Heir to the mining magnate? Well, that's something! I heard something about your cousin and you being in some sort of race?”");
+	output("\n\nYou grumble aloud. Yeah, " + chars["RIVAL"].mf("him","her") + ". Fyn diplomatically changes the topic. “Ah, like that, huh? Anyway, enjoy your drink, and if you want, I'm doing private lessons. After all, I wouldn't say no to having such a");
+	
+	if(pc.femininity >= 65) output(" beautiful");
+	else if(pc.femininity <= 35) output(" handsome");
+	else output(" striking-looking");
+	
+	output(" " + pc.mf("man", "woman")); 
+	output(" as my student.”");
+	
+	flags["FYN_APARTMENT_ENTERED"] = true;
+	CodexManager.unlockEntry("Vildarii");
+	
+	clearMenu();
+	addButton(0, "Next", mainGameMenu);
+}
+
+public function showFynsApartment():void {
+	showFyn();
+	addButton(0, "Fyn", fynMenu);
+}
+
+public function fynMenu():void {
+	showFyn();
+	clearOutput();
+	
+	//generate random number between 0-3
+	var random:int = rand(4);
+	
+	switch(random) {
+		case 0 :
+			output("The devilish-looking dancer is leaning against the kitchen bench in the middle of the room. He waves as you enter, a glint in his fiery eyes.");
+			output("\n\n“Hello there, " + pc.mf("Mr", "Ms") + " Steele. Always delighted to see you walk through my door.”");
+			break;
+		case 1 :
+			output("Fyn is reclining in a comfy looking lounge chair, sipping a glass of whisky and listening to music. As you enter, he clicks it off, and stands up.");
+			output("\n\n“" + pc.mf("Mr", "Ms") + " Steele! I was just sitting and having a drink. Here for lessons, or perhaps something else?”");
+			break;
+		case 2 :
+			output("Fyn is doing some stretches, a look of intensity in his eyes. As you approach, however, his powerful brows relax and his eyes shine.");
+			output("\n\n“Ah, " + pc.mf("Mr", "Ms") + " Steele. What can I do for you today?”");
+			break;
+		case 3 :
+			output("You catch Fyn reading a book. He's flicking through the pages, though he's standing up as he reads it. When you come over, he grins and marks the page. It seems to be a book on bondage techniques.");
+			output("\n\n“Greetings! Just catching up on some light reading. Fascinating things those siel come up with. There's more knots in some of these bindings than an ausar orgy.”");
+			break;
+	}
+	
+	clearMenu();
+	addButton(0, "Appearance", fynAppearance);
+	addButton(1, "Talk", fynTalk);
+	addButton(2, "Lesson", fynLessons);
+	
+	if(flags["FYN_TALKED_ABOUT_SEX"] == true) addButton(3, "Sex", fynSexMenu);
+	else addDisabledButton(3, "Sex", "Sex", "You don't know him well enough to suggest that.");
+	
+	addButton(14, "Leave", mainGameMenu);
+}
+
+public function fynAppearance():void {
+	clearOutput();
+	showFyn();
+	
+	output("Looking at this tall man is like looking at some wild bacchian fae rather than an alien being.");
+	output("\n\nStarting at the top, the devilish-looking man has dark, thick hair that reaches down to his shoulders; the sort you could stroke your hands through for hours. His eyes do nothing to soften his rather wicked appearance; they're passionate, crimson orbs with black, tiger like slits, capped by powerful brows. His ears, like those of all vildarii, are pointed and elfin.");
+	output("\n\nHis lips look rather inviting, and they're rarely still, whether they're moving with song, speech, or smile. If there's one thing Fyn seems to pride himself on, it's his oral skills.");
+	output("\n\nLooking down from the nape of his neck, the first thing to notice is his broad, proud shoulders and chest. They're held with some inner confidence that never seems to falter. Perhaps it's his dancing training that gives him such perfect, unwavering poise. Said chest is well displayed by his silk black shirt, deliberately left open all the way down to his slender stomach. His whole body in fact has a perfect V-like shape, starting at the shoulders down to his narrow hips; and if his shapely ass is any indication, they possess some serious thrusting power.");
+	output("\n\nHis pants are hugging his crotch in a rather suggestive way. They seem to be dance-compatible, allowing for ease of movement, and for the vildarii male to show off his impressive flexibility.");
+	output("\n\nIndependent of his physique, whenever you're close to him, you always catch a hint of a particular, alluring scent; a mixture between fresh rain and a distinctive <i>maleness</i>.");
+}
+
+public function fynTalk():void {
+	clearOutput();
+	showFyn();
+	
+	output("What do you want to talk about?");
+	
+	clearMenu();
+	addButton(0, "Fyn", fynTalksAboutFyn);
+	//unlocked after talked about Fyn
+	if(flags["FYN_TALKED_ABOUT_FYN"]) addButton(1, "Hobbies", fynTalksAboutHobbies); 
+	else addDisabledButton(1, "Hobbies", "Hobbies", "You don't know him well enough to talk about that.");
+	//unlocked after talked about hobbies + relationship 1+
+	if(flags["FYN_TALKED_ABOUT_HOBBIES"] && fynRelationshipStatus() >= 1) addButton(2, "Sex", fynTalksAboutSex);
+	else if (flags["FYN_TALKED_ABOUT_HOBBIES"] == undefined) addDisabledButton(2, "Sex", "Sex", "You don't know him well enough to talk about that.");
+	else addDisabledButton(2, "Sex", "Sex", "Fyn has no interest in talking about sex with you."); //pc did not firt and blocked sex menu
+	addButton(3, "Vildarii", fynTalksAboutVildarii);
+	addButton(4, "Career", fynTalksAboutCareer);
+	addButton(5, "Dancing", fynTalksAboutDancing);
+	//unlocked after talked about Fyn
+	if(flags["FYN_TALKED_ABOUT_FYN"]) addButton(6, "Singing", fynTalksAboutSinging); 
+	else addDisabledButton(6, "Singing", "Singing", "You don't know him well enough to talk about that.");
+	//unlocked after talked about hobbies
+	if(flags["FYN_TALKED_ABOUT_HOBBIES"]) addButton(7, "Fencing", fynTalksAboutFencing);
+	else addDisabledButton(7, "Fencing", "Fencing", "You don't know him well enough to talk about that.");
+	addButton(14, "Back", fynMenu);
+	
+	
+}
+
+public function fynTalksAboutFyn():void {
+	clearOutput();
+	showFyn();
+	clearMenu();
+	
+	if(flags["FYN_TALKED_ABOUT_FYN"] == undefined) {
+		output("You ask Fyn a little bit about himself. The devilish dancer quirks an eyebrow, shooting you a deliberately sultry look.");
+		output("\n\n“Why, are you interested...?” he asks, crossing his arms over his barely covered chest.");
+		
+		flags["FYN_TALKED_ABOUT_FYN"] = true;
+		
+		addButton(0, "Flirt", fynTalksAboutFynPcFlirts);
+		addButton(1, "HardToGet", fynTalksAboutFynPcPlaysHardToGet);
+		addButton(2, "NoWay!", fynTalksAboutFynPcIsNoFlirt);
+	}
+	else 
+	{
+		output("You ask Fyn about himself once more, curious to hear it again.");
+		
+		fynTalksAboutFynPartTwo();
+		
+		addButton(14, "Back", fynTalk);
+	}
+}
+
+public function fynTalksAboutFynPcFlirts():void {
+	clearOutput();
+	showFyn();
+	
+	fynAdjustRelationshipStatus(1);
+	
+	output("“And what if I was, hmm—?” you respond, sauntering up to him and stroking his cheek. He grabs your hand and kisses it, a very intense look in his eyes. You feel your heart skip, just a little, with the incredibly delicious tension in the air.");
+	output("\n\n“... Well then, I'd just have to keep your interest, because you certainly have <i>mine</i>,” Fyn intones, kissing your fingertips. Intoxicated by the sensation, you let out a little moan, wondering <i>where</i> this is headed. His hands then slide down your arms, trailing their way down to your waist. You're pulled against him, deliciously close, your face ever so close to his... you can feel his gorgeous lips, his heated breath, brushing against the sensitive [pc.skinFurScales] of your neck.");
+	output("\n\n“Well... where to start? My name is Fyn Wilder, though that's not my real name; just a stage name...” He informs you, now kissing your ear. A tremble courses through your body; a wonderful little shock. “... My real name is Eriladar. I'm from Merope in the Pleaides star cluster.”");
+	output("\n\n“Do you know of Merope? She was a nymph, a caretaker of Bacchus, the god of theatre, fertility, and ecstasy. They called him 'the god who comes'.”");
+	output("\n\nHow fitting! As his soft, kissing lips trail sweetly down your neck, you quiver with delight. Ecstasy and coming are definitely on <i>your</i> mind! His fingers cling to your waist, holding you fast, and you lift your chin just a <i>little</i> so he can kiss you better. Meanwhile, his words are like honey to your ears...");
+	output("\n\n“... Some of those earth cultures had real character. Loving terran culture is what attracted me to the stage. Good thing my family had me gene-modded before I was born; vocal cords touched up with a fanfir's.”");
+	
+	//Brief bit just for non taurs
+	if(!pc.isTaur()) 
+	{
+		if(IsOneOf(pc.armor, MaidOutfit, SchoolgirlOutfit, 
+				LibrarianOutfit, TopNSkirt, NurseOutfit, FemaleDoctorOutfit, 
+				CheerleaderUniform, WaitressUniform, LittleBlackDress))
+		{
+			output("\n\nAt this point, Fyn's hands slide around and down your back. You feel the hem of your [pc.armor] being hitched.");
+			if (!(pc.lowerUndergarment is EmptySlot)) output(" Fingers slide down and beneath your [pc.lowerUndergarment], until your [pc.ass] is firmly in his hands.");
+			else output(" Your naked ass is soon being firmly squeezed.");
+			
+			output(" You sigh happily and press yourself back into his hands with an eager little wiggle. It's all you can do to stop your thighs from rubbing together,");
+		}
+		else 
+		{
+			output("\n\nAt this point, Fyn's hands slide around and down your back, until your [pc.ass] is firmly in his hands. You sigh happily and press yourself back into his hands with an eager little wiggle. It's all you can do to stop your thighs from rubbing together,");
+		}
+		
+		if(pc.hasVagina()) output(" wetness");
+		else if(pc.hasCock()) output(" hardness");
+		else output(" hotness");
+			
+		output(" building");
+			
+		if(pc.hasLegs() && !pc.isNaga()) output(" between your legs.");
+		else output(" down below.");
+	}
+	
+	output("\n\n“How about you, my dear—any modifications? I'd believe it; you're criminally easy on the eyes,” Ryn asks, suckling upon your neck. You gasp as your supple skin [pc.skinFurScalesNoun] is pulled into his mouth; almost torturously teased! H-how has he found your sweet spot already, the one between your collarbone and neck—?");
+	output("\n\n“Y-yes, a little bit of modding...” you breathily admit, <i>far</i> more interested in what's happening with your neck and his lips.");
+	output("\n\n... And then, he's pulling back! You huff");
+	
+	if(pc.femininity >= 70) output(" and shoot him a pouty look");
+	
+	output(". He, however, has a sparkle in his eyes. “Oh, did you want it to go further? You should have said so.”");
+	output("\n\nYou flush. He wants to hear it from your lips, to have <i>that</i> kind of power over you. Like a maestro, coaxing each lusty note from your lips. Do you dare give it to him...?");
+	
+	fynTalksAboutFynPartTwo();
+	
+	clearMenu();
+	addButton(14, "Back", fynTalk);
+}
+
+public function fynTalksAboutFynPcPlaysHardToGet():void {
+	clearOutput();
+	showFyn();
+	
+	fynAdjustRelationshipStatus(1);
+	
+	output("You grin, telling him you don't deny you find him <i>interesting</i>, but it's simple curiosity, nothing more! By the telling glint in his eyes, you feel he doesn't believe you; which isn't surprising, since <i>you</i> don't believe you. Still, he takes your word for it, quirking one of those delicious brows.");
+	output("\n\n“... Well, far be it from me to spurn the attentions of such a");
+	
+	if(pc.femininity >= 65) output(" gorgeous ");
+	else output(" good-looking ");
+	
+	output(pc.mf("man", "woman"));
+	output(". I suppose I'll just have to tell you everything there is to know about myself.”");
+	
+	fynTalksAboutFynPartTwo();
+	
+	clearMenu();
+	addButton(14, "Back", fynTalk);
+}
+
+public function fynTalksAboutFynPcIsNoFlirt():void {
+	clearOutput();
+	showFyn();
+	
+	output("You cough, and");
+	
+	if(pc.isNice()) output(" politely");
+	else if(pc.isMischievous()) output(" light-heartedly");
+	else output(" bluntly");
+	
+	output(" tell Fyn that he's not your type. He looks wounded, or perhaps faux-wounded? “... Ah, that's a shame. Oh well, I suppose my loss is someone else's gain.”");
+	
+	fynTalksAboutFynPartTwo();
+	
+	clearMenu();
+	addButton(14, "Back", fynTalk);
+}
+
+//the second part of Fyns flirt talk to be appended to all three possible answers
+//as well as to the repeat scene of the flirt talk
+public function fynTalksAboutFynPartTwo():void {
+	output("\n\n“My full name is Fyn Wilder; or at least, that's my full stage name. Apparently 'Eriladar' apparently wasn't distinctive enough, or too hard to pronounce, so my agent suggested I axe it,” he gives a light shrug, “'Fyn Wilder' seemed like a good fit.”");
+	output("\n\n“I'm twenty eight, and my home planet is Merope, in the Pleaides star cluster. That's not too far from terra, galaxy-wise, so we got a lot of terran culture growing up. I'm actually a bit of a terraphile, truth be told; some of the old earth cultures had some real character.”");
+	output("\n\n“Loving terran culture is probably what attracted to me to the stage,” the raven-haired man pointedly touches his throat, “Thankfully, my family had me genetically modified before I was born; my vocal cords are sliced with a fanfir's. It was all the rage with vildarii back then, and it really helped keep up with the competition.”");
+}
+
+public function fynTalksAboutHobbies():void {
+	clearOutput();
+	showFyn();
+	
+	output("You ask him what his hobbies are, and he doesn't even need time to think.");
+	output("\n\n“Sex. No doubt about it. It's the only thing that comes close to performing. If I could fill my whole day with sex, I would,” Fyn stretches, much like a cat. Or perhaps rather a tiger, given those distinctive eyes of his. “That said, I do have <i>other</i> hobbies. Dancing and singing, obviously. Parties are pretty high up there; you can never go wrong with good company, drink, and music. I'm pretty sybaritic.”");
+	output("\n\n“Other than that, I love to fence—which, let's face it, is almost dancing—and bondage. Nothing more satisfying than finishing off a good bit of knotwork, particularly if you're dressing up a pretty thing with it and putting [pc.himHer] on display.”");
+	
+	if(fynRelationshipStatus() >= 1) output("\n\nBondage? You picture yourself trussed up in of silk, put on display for Ryn's satisfaction. That's <i>one</i> way to get in his bedroom, apparently!");
+	
+	flags["FYN_TALKED_ABOUT_HOBBIES"] = true;
+	
+	clearMenu();
+	addButton(14, "Back", fynTalk);
+}
+
+public function fynTalksAboutSex():void {
+	clearOutput();
+	showFyn();
+	
+	output("Fyn seems awfully interested in sex. He also said he was into bondage. You ask the devilish-looking man if he's a Dominant.");
+	output("\n\n“Yes, I'm definitely a Dom. That's not to say I don't like vanilla; I love a taste of the traditional just as much as I like having a tied-up treat in the playroom,” he explains, then winks. “And yes, I <i>do</i> have a playroom. I buy a lot from the Happy Tails, and not all of it fits in the bedroom.”");
+	output("\n\n“Do you have a sub?” you ask, and he shakes his head.");
+	output("\n\n“No, I <i>did</i> have one, but not anymore—a lover and a sub. I'm not polyamorous, so I like to be dedicated to one person at a time. I don't mind if my lover sleeps around, so long as their heart belongs to me. I'm rather possessive that way.”");
+	output("\n\nIt's a bit surprising to hear such a wild and wicked looking guy is actually somewhat monogamous. Or rather, he's into open relationships, for all his kinks.");
+	
+	flags["FYN_TALKED_ABOUT_SEX"] = true;
+	
+	clearMenu();
+	addButton(14, "Back", fynTalk);
+}
+
+public function fynTalksAboutVildarii():void {
+	clearOutput();
+	showFyn();
+	
+	output("You ask Fyn about the vildarii. You're interested to hear about his species. The midnight-haired man seems happy to answer your questions, leaning back a little as he does so.");
+	output("\n\n“... Well, where to start? We're fantastic, mostly because I'm one of them,” Fyn states, a playful glint in his eyes.");
+	output("\n\n“Humble!”");
+	output("\n\n“I know, I am. All performers are, you know,” he winks, then crosses his arms. “Hmm, I guess I should give a serious answer, spreading culture and all that. Where to start?”");
+	output("\n\n“How about the fact you're all polymorphs?” you suggest, and he nods.");
+	output("\n\n“Yes, we are, though we're not the best out there. Not the worst, either. A lot of people think we're just all born with the ability to switch into whatever we please, but it's not really that simple.");
+	output("\n\n“It actually takes an awful lot of training over many, many years, and even then, you've got to have a natural knack for it. It's a bit like singing, in that respect. Most terrans and ausar can sing, for example, but not all are good at it.”");
+	output("\n\n“Not only did I study polymorphing at school, I specialized in it at theatrical college. I also honed it as a stripper while I was paying off my tuition fees. It's a lot of work, this face changing business,” Fyn explains, giving a faux-sigh. “Most everyday vildarii can only change their color, and the shape of our eyes and ears. The dead giveaways.”");
+	output("\n\n“And you—?” you ask, your curiosity piqued.");
+	output("\n\n“Well, I can change the overall texture, shape, and color of everything, really. Sprouting ausar ears or kaithrit whiskers, for example, or even an extra phallus should the mood suit me. On a good day, I can do a tail, but that's a <i>lot</i> of work.”");
+	output("\n\n“That said, it's not as easy as it looks. Every time I change, I need to binge eat like crazy; transforming burns up things like fats and sugars, so come performance time, I've got to chow down like my life depends on it. Not a bad deal, though, eating so much and never having it hit the hips.”");
+	
+	clearMenu();
+	addButton(14, "Back", fynTalk);
+}
+
+public function fynTalksAboutCareer():void {
+	clearOutput();
+	showFyn();
+	
+	output("You ask Fyn about his career. You recall that he was meant to be a young up-and-coming actor, at least if the holos were to be believed.");
+	output("\n\n“Yeah. Well, I did make it big time. I was cast a big role with the Starlanders; that's a theatrical company that do holo-productions as well. I would have been broadcast large as life, all three dimensions across countless star systems...”");
+	output("\n\nFyn pauses and looks off into a random direction, furrowing his brow.”... And someone very close to me died. I didn't really have it in my heart to perform after that,” he pauses for a moment. “...It nearly killed my agent, but I decided to quit and come out here to the edges of Rush space.”");
+	output("\n\nYou ask him what he's looking for, out here on the edges of known space, and Fyn gives a somber smile. “Honestly? I don't know. All I knew is I wasn't going to find it back there in the core.”");
+	
+	clearMenu();
+	addButton(14, "Back", fynTalk);
+}
+
+public function fynTalksAboutDancing():void {
+	clearOutput();
+	showFyn();
+	
+	output("You ask Fyn why he loves dancing so much. The midnight-haired man strokes his chin, seemingly trying to articulate his answer.");
+	output("\n\n“Well, it's expression. It's energy. It's... quite obviously hard to explain. You're in the moment, and in that moment you're <i>free</i>; nothing else matters. You're just swallowed by this adrenaline rush, this sort of pure, all-encompassing joy.”");
+	output("\n\nBy the passionate glint in his eyes, it seems he <i>really</i> likes dancing. You ask him what kind he likes.");
+	output("\n\n“Well, I have a soft spot for ballroom dancing; there's something particular about the intimate dynamic of two people dancing, bodies pressed together. Theatrical dance too, though that's more expression.”");
+	output("\n\n“Oh, and and strip tease. Definitely strip tease.”");
+	output("\n\nYou remark that strip tease doesn't seem to fit with the other two classical arts, and Fyn winks.");
+	output("\n\n“When I do it, hun, it's an art. Trust me. Being able to make someone's practically flutter back into their head, just with how much you're winding them up? Forget art; that's practically <i>magic</i>.”");
+	
+	if(fynRelationshipStatus() >= 1) output("\n\nYou look down at Fyn's hips, imagining him giving you a hot strip tease... and suddenly you feel <i>yourself</i> swooning. He's not half wrong; that <i>would</i> be like magic.");
+	
+	clearMenu();
+	addButton(14, "Back", fynTalk);
+}
+
+public function fynTalksAboutSinging():void {
+	clearOutput();
+	showFyn();
+	
+	output("You remember Fyn mentioning he was a singer who had fanfir gene mods spliced in before he was born, so you ask him about it.");
+	output("\n\n“Yeah; know much about the fanfir? Gigantic, dragon-like creatures, like out of Der Ring des Nibelungen. Actually, I sang with a female fanfir during Der Ring des Nibelungen; I was Sigurd, and she played the dragon. Her, uh hypnotic voice was <i>very</i> captivating. Even though I slayed her on stage, she was the one who felled <i>me</i>; apparently she had quite the taste for young male actors.”");
+	
+	//if pc's intelligance is higher than half the current max
+	if(pc.intelligence() > (pc.intelligenceMax() / 2))
+	{
+		output("\n\n“Der Ring der Nibelungen? Isn't the dragon meant to be played by a man?” you ask, recalling the famous terran opera. The moment you say that, Fyn's eyes fly open, and his smile couldn't be wider.");
+		output("\n\n“...You know it? Yes, the dragon <i>is</i> meant to be played by a man, traditionally. There were a few creative differences. The role of the Norn was played entirely by one siel woman, who had six arms to play string instruments with.”");
+		output("\n\n“Nibelungen is rarely performed outside of the sol system. My belief is Tiana—the lady fanfir—bankrolled the production to have her pick of young, strapping singers.”");
+	}
+	else 
+	{
+		output("\n\nYou state that you've never heard of the piece, and Fyn nods. “I'm not surprised. It's a pretty rare piece, hardly performed outside of the sol system. My belief is Tiana—the lady fanfir—bankrolled the production to have her pick of young, strapping singers.”");
+	}
+	
+	output("\n\n“If it wasn't for the fact someone new came along to play with, I doubt I'd have escaped her clutches. The fanfir have highly evolved vocal cords; they can lightly manipulate your thoughts and even hormones through their singing. It's much like being caught under a witch's spell.”");
+	output("\n\n“That said, even though I abhor being on the bottom, I'd <i>highly</i> recommend sleeping with a fanfir if you get the chance. It's definitely an experience and a half.”");
+	output("\n\nSo, does that mean Fyn can do what fanfir can do? The singer smiles and shakes his head.");
+	output("\n\n“Not to that degree. I mean, fanfir have massive throats. Even when they talk, it's truly captivating. My birthright only gives me a superior singing range.”");
+	
+	clearMenu();
+	addButton(14, "Back", fynTalk);
+}
+
+public function fynTalksAboutFencing():void {
+	clearOutput();
+	showFyn();
+	
+	output("Fencing seems like an interesting hobby, so you ask Fyn about it. He strides over to a wicker-basket and pulls out a what looks like a fencing sword. The raven-haired man gives it a lazy flourish.");
+	output("\n\n“... Good for footwork. That's why I originally started. Some learn it for practicality—rushers in particular—while other for sport. Me? I do it for fun.”");
+	output("\n\nHe hands you the fencing sword, and you take it. Feels light, very light; some sort of special blade? There's a switch at the handle, and you flick it. There's suddenly a low hum coming from the blade, and when you touch it against the ground, there's a light blue crack.");
+	output("\n\n“It's a stun blade. I'm not one for wearing silly outfits or wearing shields. It's one of the few sports that requires both mind and body in even measure. Self discipline, too. Whether you win or lose, with fencing, it's up to you. Misinterpret a parry, you change tactics or you lose. You need quick thinking <i>and</i> quick feet.”");
+	output("\n\nJust like everything he does, Fyn seems rather passionate about fencing, too. You could probably get you to teach him a few things about it. Maybe it'll help you out in rush space?");
+	
+	flags["FYN_TALKED_ABOUT_FENCING"] = true;
+	
+	clearMenu();
+	addButton(14, "Back", fynTalk);
+}
+
+public function fynLessons():void {
+	clearOutput();
+	showFyn();
+	
+	output("What would you like a lesson in?");
+	
+	clearMenu();
+	addButton(0, "Dancing", fynTeachesDancing);
+	addButton(1, "Stripping", fynTeachesStripping);
+	if(flags["FYN_TALKED_ABOUT_FENCING"] == true) addButton(2, "Fencing", fynTeachesFencing);
+}
+
+public function fynTeachesDancing():void {
+	clearOutput();
+	showFyn();
+	
+	if(flags["FYN_TAUGHT_DANCING"] == undefined) 
+	{
+		output("“There's a dance studio next door. You might want to change into something more comfortable, though,” Fyn grins.");
+		
+		if(pc.isNude()) 
+		{
+			output("\n\n“But why wear clothes when I could be naked?” you ask, putting a pointed hand on your bare hip.");
+		
+			if (fynRelationshipStatus() >= 1) output("\n\n“Well, if you dance like that, we're not going to end up dancing; we're going to end up in the bedroom,” Fyn wiggles a brow. “... So it's clothes and classes, or no clothes and no classes.”");
+			else output("\n\n“Who said the clothes were for you? There's no way I can teach you when you're naked like that!”");
+		}
+	}
+	//if pc had dance lessons before
+	else
+	{
+		output("You head into a side room and, after throwing on some dance-friendly clothes");
+		if (pc.isTaur() || pc.isNaga()) output(" onto your upper half");
+		output(", meet him in the side studio. There's some music already playing and Fyn is standing in the middle of the room. He then starts the lesson.");
+	}
+	
+	//generate random number between 0-4
+	var random:int = rand(5);
+	
+	switch(random) {
+		case 0 :
+			output("\n\n“Today, we'll be doing general dance technique. Posture is important to all forms of dance,” Fyn explains, straightening himself out, “You need to stand straight, push your shoulders down and back, and hold your head up. Just this simple thing alone does wonders for any dancer.”");
+			output("\n\n“Another simple yet effective trick is <i>smiling</i>. Whether you're doing a striptease or a tango, a smile is an expression of pleasure, happiness, and amusement. If you smile while you're dancing, people will get the feeling you love what you are doing. Even if you're dancing on your own, smile—you love to dance, so let it show!”");
+			output("\n\nAfter going over the theory, the lesson turns to practice. Fyn coaches you on proper posture and poise, circling around and giving advice where he thinks it needs work.");
+			output("\n\n“Good job! The fundamentals are vitally important; no matter what you build, if the foundation is sloppy, the whole thing won't stay standing. You can practice your poise while doing anything, so try to wherever and whenever you can!”");
+			break;
+		case 1 :
+			output("\n\n“Today, we'll be doing general dance technique,” Fyn informs you, tapping his head. “Half of becoming a good dancer is dealing with what's up here. There's anxieties and stresses that build up when you try to dance. There's an inner critic in your head, just like a little child trying to distract you from doing worthwhile things. Telling you you're being judged and you're lacking. Hit the ignore button on them!”");
+			output("\n\n“So instead of thinking, feel. Don't focus on the actual steps, but think about how it feels. The more you allow your body to do the dance thinking, the more you'll develop muscle memory, and stop worrying in your head.”");
+			output("\n\nAfter going over the theory, the lesson turns to practice. Just as he suggested, you try to dance on instinct, going with your feelings rather than your thoughts. It's incredibly liberating, and you find your whole body relaxes, making it easier to dance in turn.");
+			break;
+		case 2 : 
+			output("\n\n“Today, we'll be doing salsa lessons,” Fyn grins, taking you by the hands. “Now, Salsa is a popular kind of terran dance style that spread out to Alpha Centaurii. There, it turned into what's called the 'Hot Trot'; they ditched the twirls and kept the footwork.");
+			if (pc.isTaur()) output("Since you're a taur, we'll be doing the Hot Trot.");
+			output("\n\n“The reason is simple; in many styles of Salsa, as a dancer shifts their weight by stepping, their upper body remains level and nearly unaffected. That means it's perfect for leithans to show off their fancy hoofwork, so long as their partner isn't trying to twirl them. Instead, they incorporated the swift side-trot and the cross-trot, allowing them to rotate around the floor in a fast, showy pattern.”");
+			output("\n\n“Practicing with Cha-Cha music is a great way to practice Salsa, because it's essentially Salsa, but slower. Now, as the follower, you need to be attuned to what the leader is telling you to do. Move instinctively in the direction I'm pushing you in, going with the flow.”");
+			output("\n\nYou practice Salsa, Hot Trot, and Cha-Cha with Fyn for a while, moving to the beat of the New Latin rhythm. Once you're finished, you're totally puffed! Fyn has a knowing look on his face.");
+			output("\n\n“...Yeah, dancing those styles can be pretty exhausting; they've got a pretty high beat-count compared to normal dances, so you naturally speed up. But you should feel good, you nailed it!”");
+			break;
+		case 3 : 
+			output("\n\n“Today, we'll be doing belly dancing lessons,” Fyn takes a step back and strips off his shirt.");
+			if (fynRelationshipStatus() >= 1) output(" You try quite hard not to ogle his utterly male physique, but fail utterly!");
+			output("“Now, contrary to common belief, anyone can belly dance, no matter their sex or physique, so long as they have hips. Here, let me show you.”");
+			output("\n\nYou watch as Fyn sensually gyrates his narrow hips, then begins to thrust and punctuate it to the beat of the music. He uses hip rolls, lifts and twists in time with the music, even moving his chest and shoulders in time with the beat.");
+			output("\n\n“... See? That's one element of belly dancing; percussive movement. There's also fluid movement—that's the kind best suited to galotians and rahn—where you continuously move your body in flows and coils. It requires a great deal of abdominal muscle control. Then there's shimmying, which can give the impression you're moving a lot more than you are; shimmying with your knees, hips, shoulders, they all add to the dance.”");
+			output("\n\n“Throw in some other movements like traveling steps, turns, spins, kicks, backbends, and head-tosses, and you've got yourself quite the show, no matter how masculine or feminine you look. We'll go over each of these moves individually, then combine them over time, working our way up to a full-blown belly dance.”");
+			output("\n\nAfter going over the theory, the lesson turns to practice. Just as he said, you practice all the individual elements, then add them bit by bit to your dancing routine. By the end of the lesson, you're totally exhausted; moving so much is a real workout!");
+			break;
+		case 4 :
+			output("\n\n“Today, we'll be doing flamenco lessons,” Fyn takes a step back. His fiery eyes are glinting. “... I have to admit, I <i>love</i> Flamenco. It's one of my favorite styles of dance.”");
+			output("\n\n“The word 'flamenco' comes from a terran word for 'flame' or 'fire', and that's because it's full of expressive, passionate, and seductive moves. It's high intensity, and involves a lot of rhythm, finger-snapping and hand-claps. It also goes fantastically with singing, which, of course, I love.”");
+			output("\n\nFyn really does sound passionate about it! But then, what doesn't he sound passionate about? “... Now, with flamenco, it can be performed solo, or with a partner. But most important is the feeling, the passion! You hold yourself proudly, expressively using your arms and stamping your feet. You must dance it as if you are on fire with your emotions.”");
+			output("\n\n“Here are some moves, repeat after me. It's mostly improvised—all passionate things are—so do not feel pressured to learn all the moves at once.”");
+			output("\n\nYou watch and try to repeat his passionate, flurrying dances, feeling the heat rise in the air. The dancing <i>is</i> wild, and outrageously fun, and even when you're exhausted otherwise you <i>still</i> feel a lasting thrill.");
+			output("\n\n“Fantastic! The flamenco suits you. You must have a <i>lot</i> of passion in your heart,” Fyn remarks, then winks, “Remember to practice in your spare time. Just try not to be so hot that you set fire to something.”");
+			break;
+	}
+	
+	flags["FYN_TAUGHT_DANCING"] = true;
+	
+	clearMenu();
+	addButton(0, "Next", fynMenu);
+}
+
+public function fynTeachesStripping():void 
+{
+	clearOutput();
+	showFyn();
+	
+	output("You ask Fyn for some striptease lessons, and he leads you to the dance studio next door. You both stroll out to the middle of the floor. Once there, the vildarii man waves his hand through the air, setting some tunes. He then starts the lesson.");
+	
+	//generate random number between 0-5
+	var random:int = rand(6);
+	
+	switch(random) {
+		case 0 :
+			output("\n\n“The most important part of a strip tease is often the most overlooked. It's not your tits, your package, or your ass; it's your <i>eyes</i>,” he stresses, gesturing with twin fingers to his own fiery orbs. “... Keep eye contact! The way you look at your partner is the most vital and <i>powerful</i> elements of a striptease.”");
+			output("\n\n“It helps to assume some kind of persona; something sexy, like a French dominatrix, or a Russian spy. Perhaps a devil; that's my personal favorite.”");
+			output("\n\nAfter going over the theory, the lesson turns to practice. You attempt to dance while keeping steady eye contact... and it's harder than it looks! Keeping a sensual stare while moving about is tricky, and you have a renewed respect for strippers. At the end of the lesson, Fyn grins and throws you a towel.");
+			break;
+		case 1 :
+			output("\n\n“Wearing nothing is for amateurs. There's no surprise, no mystery, no presentation. If you want to truly tantalize someone, you want <i>layers</i>. Not too much, not too little. Things you can take off in a seemingly effortless manner, deliberately and slowly, in order to work your 'victim' into a sexual frenzy.”");
+			output("\n\n“Don't just choose your outfit for them; pick it for you, too. Wear something that fits you well and makes you feel sexy. A successful strip isn't about what outfit the audience would prefer; it's about exuding confidence and sensuality, so focus on what makes <i>you</i> feel that way.”");
+			output("\n\nAfter going over the theory, the lesson turns to practice. You're given a few easy-to-wear pieces and asked to strip them off, slowly and sensually, projecting confidence. It's tricky to not rush it! At the end of the lesson, Fyn grins and throws you a towel.");
+			output("\n\n“It's harder with an outfit someone else gives you; you did well. Try stripping in a few different outfits—you never know <i>when</i> you'll have to strip tease your way out of a situation,” Fyn winks.");
+			break;
+		case 2 :
+			output("\n\n“Always remember, when it comes to stripping, there are no strict rules. Don't just memorize a dance routine, or think there's an 'order' of undressing. What a turn off, for you <i>and</i> the audience! Just play it by ear, <i>watch</i> their faces, do what you like, and above all, enjoy the process!”");
+			output("\n\n“If you feel more comfortable with routine, that's okay, but add your own touch—your own flare—to your performance. Own it, it's yours!”");
+			output("\n\nAfter going over the theory, the lesson turns to practice. After dancing a few routines, you're asked to free-style the strip tease. It takes a little getting used to making things up on the fly, but once you start to feel the music in the background, it becomes much easier.");
+			break;
+		case 3 :
+			output("\n\n“When it comes to stripping, a tried-and-true starter is going from the top—unbuttoning it slooowly—while making steady eye contact. Catch them with your gaze, draw it out, maybe move to your skirt or pants. Play around with your clothes a bit, twirling them, or throwing them at your audience. Make it fun, keep them guessing—it's called a strip <i>tease</i> for a reason!”");
+			output("\n\n“Don't just throw things everywhere, though. Let some things fall to the floor; there's things that fall down better than others. Slip tops, baby dolls—these are <i>perfect</i> for sliding down your body. Remove them while standing up, and make eye contact the entire time with your partner.”");
+			output("\n\nAfter going over the theory, the lesson turns to practice. Fyn asks you to undo your top slowly, and for some reason, it's harder than it looks to make look sexy at the same time. You twirl around your top, tossing it at him, then do it again a few times with just letting it fall to the floor. At the end, the dancer gives a round of applause.");
+			output("\n\n“Good job! This lesson's an easy one to practice, particularly in front of a mirror. Then again, an audience is always better, so maybe ask a lucky friend,” Fyn suggests, wearing a very mischievous smile.");
+			break;
+		case 4 :
+			output("\n\n“You're in control when it comes to the strip tease. Wherever you want your audience's eyes to go? Make your hands go there. And whatever you do is right, because it's your show, and you set the rules. You can even forbid them to touch you, if that's your desire; the playful act will tease them even more, giving you more control over them and over the power of your dance.”");
+			output("\n\n“Remember; it's not your technique that seduces; it's your mood and distinctive manner. Move confidently but slowly; if you breath deeply, it will slow you down and add subtle sensuality to your moves.”");
+			output("\n\nAfter going over the theory, the lesson turns to practice. You practice breathing and using your hands to draw eyes where you want them to go, moving as slowly and confidently as possible. You seem to be doing well, because there's an approving smile playing on Fyn's lips.");
+			break;
+		case 5 :
+			output("\n\n“For most species, the groin is where an audience's attention naturally wants to go. It's also what you want to leave for <i>last</i>, whether you're male, female, or otherwise.”");
+			output("\n\n“Even if you've got the equipment to dazzle them, don't. Mystery is a delicious spice that is at the heart of a striptease. If you wiggle your naked body around on stage, half the fun is already gone; they may as well pack up and leave.”");
+			output("\n\n“Underwear last! And yes, remember to wear it before the performance begins. For those who can't always reach their underwear, like leithans, it's the top that comes last; whatever's hiding your last erogenous zone. Your audience is salivating over whatever body parts they're fantasizing about. Chest. Stomach. Ass. Groin. Reveal each one slowly, make them wait for it. Keep them on the edge of their seat!”");
+			output("\n\nAfter going over the theory, the lesson turns to practice. You practice drawing out your striptease, keeping particular parts of your body covered until the last, then saucily revealing it in slow, deliberate movements. When you finish, Fyn nods, a look of approval in his eyes.");
+			break;
+	}
+	
+	clearMenu();
+	addButton(0, "Next", fynMenu);
+}
+
+public function fynTeachesFencing():void
+{
+	clearOutput();
+	showFyn();
+	
+	output("You ask Fyn for some fencing lessons, and he leads you to the dance studio next door. You both stroll out to the middle of the floor. Once there, the vildarii man tosses you a stun saber. You both activate them, and they let out a low, crackling hum.");
+	
+	//generate random number between 0-4
+	var random:int = rand(5);
+	
+	switch(random) {
+		case 0 :
+			output("\n\n“Today, we'll be focusing on lunging and flunging. A lunge is one of the most standard but highly effective attacking movements. First, assume the basic fencing position...” Fyn gets in stance, “... then, extend your right foot as far as possible without overstretching or losing your balance.”");
+			output("\n\n“As you lunge towards your opponent, you want to <i>extend</i> your sword arm and engage them with a stab or slash. A flunge is basically a flying lunge—hence the name—where you do it with a flying leap. It gives you a greater element of surprise and speed, but don't use it too much, because it leaves you wide open!”");
+			output("\n\nYou practice lunging, both on ground and in the air, with Fyn. The flurry of cracking blades is exhilarating, and you feel the adrenaline coursing through your body. When practice is finished, your heart is rushing, but you're riding a fencer's high!");
+			break;
+		case 1 :
+			output("\n\n“Today, we'll be focusing on the 'passata sotto'. It's an evasive movement twist. First, I want you to attack me—go for my upper body or head.”");
+			output("\n\nYou lunge forward with the blade, striking where he says. As you do so, Fyn suddenly drops to one knee, placing one hand on the ground. As you loom over him, he straightens his sword arm, striking you on your exposed chest!");
+			output("\n\n“... The 'passata sotto' is an evasive movement and counter-attack, involving a drop and twist. It's a risky move, because if you time it wrong, or misread your opponent's body language, you're going to get skewered. Only use it when you're sure where they're going to strike! Now you try.”");
+			output("\n\nAs Fyn strikes at you with mock blows, you attempt to replicate the passata sotto, ducking under his blade and striking at his body. Getting the timing right is hard! It occurs to you that you could use this with either gun or sword, just so long as you evade and strike.");
+			break;
+		case 2 :
+			output("\n\n“Today, we're working on parry and riposte. I want you to strike at me, wherever you wish.”");
+			output("\n\nYou lunge at Fyn, and he quickly parries your blade. While you're outstretched, he quickly strikes back, tapping you on the arm.");
+			output("\n\n“A parry is a defensive move where you block or deflect an opponent's attack with your blade. It doesn't need to be your blade, though; it could be a gun barrel, or even an object you pick up off the ground. The main thing is to figure out where your opponent's hit will land, then move your defending weapon in a certain sweeping path to knock it off course.”");
+			output("\n\n“Like water, you want to redirect, not directly oppose. Then, when your opponent is stretched out, strike back! Nothing is more shocking to someone then reaching out to strike someone, and instead of landing a hit, getting struck back instead.”");
+			output("\n\nYou practice parrying and riposting with Fyn until you swear your arm is going to fall off! After the lesson, though, you're feeling like you're much better for drilling in the basics.");
+			break;
+		case 3 :
+			output("\n\n“Today, we'll be working on counter-attacks and remise. A counter attack is where, as your opponent attacks, you launch one right back at them. The aim is not to parry, but to hit the opponent before they hit you. Even though they strike first, you want to <i>hit</i> first, and take them down before they land their hit.”");
+			output("\n\n“From a counter-attack, we'll practice going into a remise. A remise is a short series of attacks where you do not withdraw your weapon arm; you just keep on striking without mercy. When you've got an opponent off-guard and open, you want to deal all the damage you can, to put an end to the fight as soon as possible!");
+			output("\n\nYou practice counter-attacking and remise with Fyn; it occurs to you as you train that the same principles apply for any weapon, not just fencing. At the end, you feel much more confident having something swung at you, and in the fact that if need be, <i>you'll</i> be the last one standing at the end of a fight!");
+			break;
+		case 4 :
+			output("\n\n“Today, we'll be practicing feints. Feints are one of the best moves in your repertoire; you always want to keep your opponents off-guard and guessing. Never be predictable,” Fyn grins; you get the impression he doesn't just mean with fencing!");
+			output("\n\n“... You want to trick your opponent by launching one or more fake attacks, with the intent of creating a gap in their defense. When you do, you want to do it from different distances and with many different footwork combinations. If you use the same feint, over and over, they'll see through it in no time.");
+			output("\n\nFyn feints against you for a while, leading by example and showing you some different kinds. You then practice what you've learned on him, trying to break through his defenses. Once the lesson is over, you feel like you're more astute than ever, and on top of your game.");
+			break;
+	}
+	
+	clearMenu();
+	addButton(0, "Next", fynMenu);
+}
+
+public function fynSexMenu():void 
+{
+	clearOutput();
+	showFyn();
+	
+	//if first time sex move on to hike & fuck
+	if(flags["FYN_SEXED"] == undefined) {
+		fynSexHikeAndFuck();
+	} 
+	else 
+	{
+		output("What kind of sex?");
+		
+		//buttons need to be generated within the if/else to avoid overriding the buttons of hikeAndSex.
+		clearMenu();
+	
+		var ravishText:String = (pc.isBimbo()) ? "HulkRavish" : "OrcRavish";
+		
+		addButton(0, "Hike&Fuck", fynSexHikeAndFuck);
+		addButton(1, "Double.D", fynSexDoubleD);
+		if(!pc.isTaur()) addButton(2, ravishText, fynSexOrcRavish, undefined, ravishText, "It involves getting butt ravished by an orc-transformed Fyn. Who'd have thunk it?");
+		else addDisabledButton(2, ravishText, ravishText, "You can't be a taur to get ravished by an orc-transformed Fyn.");
+		
+		addButton(14, "Back", fynMenu);
+	}
+}
+
+public function fynSexHikeAndFuck():void 
+{
+	clearOutput();
+	showFyn();
+	
+	output("You watch wide-eyed as Fyn suddenly strides towards you. There's a purposeful look in his captivating eyes. He stops tantalizingly close");
+	
+	if(pc.tallness < 77) output(", looking down on");
+	else output(" to");
+	
+	output(" you. Your gazes meet and lock, and you find yourself suddenly swept away from reality, caught up in the intensity of those fiery, glowing eyes.");
+	output("\n\n“Wuh-what are you doing?” you half-whisper, under your breath.");
+	output("\n\n“I'm going to kiss you, of course,” Fyn informs you, as if this was decided long ahead of time. As you open your mouth to protest, he leans forward and seals it with his own supple lips. His tongue, untamed, dances with yours, filling your mouth with an unspeakable, exquisite <i>sweetness</i>.");
+	output("\n\nIt's impossible not to swoon. You find your arms subconsciously slipping around his slender waist, your fingertips clasping desperately, frantically, at his delicious back. Do you want this? Right now you do, more than anything in your life; so much it hurts. Your tongue reaches out to his, yearningly, dancing with it in heavenly harmony.");
+	output("\n\nYou feel a pressing at the small of your back; a hand, to stop you from falling? He pulls his lips back, and you're left staring up into those impossibly handsome eyes that seem to hold all the mysteries of the universe. A pair of powerful hands slide up the side of your thighs");
+
+	if(IsOneOf(pc.armor, MaidOutfit, SchoolgirlOutfit, 
+		LibrarianOutfit, TopNSkirt, NurseOutfit, FemaleDoctorOutfit, 
+		CheerleaderUniform, WaitressUniform, LittleBlackDress) && !pc.isTaur())
+	{
+		output(" and under the hem of your [pc.armor].");
+		
+		if(!(pc.lowerUndergarment is EmptySlot) && !pc.isTaur()) 
+		{ 
+			output(" Your [pc.lowerUndergarment] are pointedly pushed aside.");
+		}
+		
+	} 
+	else if(!(pc.armor is EmptySlot))
+	{
+		output(". In a frenzy of kisses, suddenly your [pc.armor] is being removed");
+		if (!(pc.lowerUndergarment is EmptySlot)) output(" along with your [pc.lowerUndergarment]");
+		output(".");
+	}
+	 
+	if(pc.hasVagina() && !pc.isTaur()) {
+		output(" He pulls out his manhood and presses it against your slick wetness, joining his body to yours.");
+		if(pc.vaginalVirgin) output(" You feel a momentary pain, followed by a warm trickling down your thigh. Blushing furiously, you cling to him, letting out a little whine.");
+	}
+	else
+	{
+		output(" He spins you on the spot and, pulling you back against his chest, presses his manhood between your buttocks. You blush as he parts your cheeks and presses inside of you, joining his body to yours. Blushing furiously, you try to relax your rectum,");
+		if(pc.analVirgin) output(" letting him in where nobody has gone before! You whimper as he pushes deeper, his prick exploring your virgin depths.");
+		else output(" letting him in with a happy tremble.");
+	}
+	
+	//if a female vaginal virgin or a male anal virgin or a taur anal virgin (as fem taurs get anal pen.)
+	if ((pc.hasVagina() && pc.vaginalVirgin) || (pc.hasCock() && pc.analVirgin) || (pc.isTaur() && pc.analVirgin)) 
+	{
+		output("\n\nFyn stops, pulling back with wide eyes. “... I'm sorry, was I your first?” You nod in response, nuzzling into him, and urging him to continue.");
+	}
+	else {
+		output("\n\n");
+	}
+	
+	output(" You gasp as you feel his engorged tip sliding up inside of you, making its way into your belly. Needily, you rock your hips and grind");
+	if(pc.hasVagina() && !pc.isTaur()) output(" against his hips and base");
+	else output(" your [pc.ass] back against him");
+	
+	output(", groaning as his stiff rod stirs around and makes its presence felt inside of your");
+	
+	if(pc.hasVagina() && !pc.isTaur()) output(" sex.");
+	else output(" rump.");
+	
+	//TODO: use Fyn Class to determine cockVolume
+	if(pc.hasVagina() && !pc.isTaur())
+	{	
+		pc.cuntChange(0, 40, true, true, true);
+		//currently broken for null reference pointer, because of ovilium update
+		//pc.loadInCunt();
+	}
+	else 
+	{
+		pc.buttChange(40, true, true, true);
+		pc.loadInAss();
+	}
+	
+	output("\n\nYour devilish lover's muscular hips slap against your");
+	if(pc.hasVagina() && !pc.isTaur()) 
+	{
+		if (pc.hasLegs() && !pc.isNaga()) output(" inner thighs");
+		else output(" body");
+	}
+	else {
+		output(" cheeks");
+	}
+	
+	output(". He's groaning long and low, his own fingers clinging to your");
+	
+	if(pc.hasVagina() && !pc.isTaur()) output(" back");
+	else if(!pc.isTaur()) output(" stomach");
+	else output(" animal ass");
+	
+	output(" as he pulls you as <i>close</i> and <i>hard</i> as he can onto his straining staff.");
+	output("\n\nYou blush as you can feel his tip flexing deep inside of you, threatening to spill his seed inside you at any moment, filling you up with his liquid satisfaction. The thought makes you hotter, hornier, and you're wildly arching and grinding up against him, utterly swallowed by lust. As you feel his final flex, you let out a sweet, shuddering cry and climax on top of his thrusting rod, clinging hard to him as you shiver and shake.");
+	
+	if(pc.hasCock() && pc.cocks.length == 1) output(" A hot jet of [pc.cumNoun] shoots up and splatters");
+	if(pc.hasCock() && pc.cocks.length > 1) output(" Hot jets of [pc.cumNoun] shoot up and splatter");
+	
+	if(pc.hasCock() && pc.hasBreasts()) output(" the underside of your boobs.");
+	if(pc.hasCock() && !pc.hasBreasts()) output(" your chest.");
+	
+	output(" You feel a slick warmth spreading out inside your");
+	
+	if(pc.hasVagina() && !pc.isTaur()) output(" pussy");
+	else output(" ass");
+	
+	output(" as his cock flexes and clenches. You blush and swoon with delight; he's cumming inside of you!");
+	
+	if(pc.hasVagina() && !pc.isTaur()) output("You bury your face into his neck, pressed sizzlingly close.");
+	
+	if(!pc.isTaur()) 
+	{
+		output("\n\nYou feel a stroke against your cheek. Crooning instinctively, you press yourself against his digits, feeling delightedly dazed.");
+		if (pc.hasVagina()) output("\n\nThere's a sweet pressing against your lips—another kiss! You return it instinctively, giddily, like embracing a long-time lover.");
+	}
+	
+	output("\n\n“... I can feel");
+	
+	if(pc.hasVagina()) output(" you running down my cock");
+	else output(" my heat filling you up");
+	
+	output(",” Fyn deeply murmurs. You grin; you can <i>also</i> feel his creamy slickness");
+	
+	if(pc.hasVagina() && !pc.isTaur()) output(" sliding out of where the two of you are joined. Far more, though, is still");
+	output(" inside of you, penned in by his half-erect cock and leaving an exquisite warmth.");
+	output("\n\nOnce he pulls out, you readjust yourself, feeling utterly dopey and quite flushed. Meanwhile, Fyn has a mischievous, self-satisfied look in his eyes; clearly he relished just ravishing you on the spot!");
+	
+	fynSexed(1);
+	
+	pc.orgasm();
+	processTime(15 + rand(10));
+	
+	clearMenu();
+	addButton(0, "Next", fynMenu);
+}
+
+public function fynSexDoubleD():void {
+	clearOutput();
+	showFyn();
+	
+	if(flags["FYN_SEXED_DOUBLE_DICK"] == undefined) {
+		output("Curious, you ask Fyn if he's able to grow a second dick? An amused look lights his face. Without warning, the dark-haired man shamelessly strips off his pants, leaving you staring at his scarlet manhood. It hangs in a foreskin halfway to his knee.");
+	} 
+	else {
+		output("With flushing cheeks, you ask Fyn if he can do that trick where he grows two dicks again? He flashes you a roguish grin and nods. The dark-haired man then shamelessly strips off his pants, leaving you staring at his scarlet manhood, hanging halfway to his knee.");
+	}
+	
+	output("\n\n“Give me a moment,” he states, closing his eyes in apparent focus. A second protrusion begins to form above his shaft. The lump grows in size and protrudes outwards, rolling down the length of his already existing cock. It stops short of his crown. It duplicates its shape, leaving him with two huge hanging dicks, one resting on top of the other. “There you go. Interested in double the pleasure?”");
+	
+	if(pc.hasVagina() && !pc.isTaur()) 
+	{
+		output("\n\n“Oh, I don't know, are you~?” you grin");
+		
+		if(!pc.isNude()) {
+		output(" sliding your [pc.armor] off. Then you");
+		if (!(pc.lowerUndergarment is EmptySlot)) output(" slide your [pc.lowerUndergarment] to one side and");
+		output(" flash him your [pc.pussies].");
+		}
+		else 
+		{
+			output(" and gesture down to your [pc.pussies].");
+		}
+		output(" “Care to use");
+		if (pc.vaginas.length == 1) output(" this and my ass at the same time?”");
+		if (pc.vaginas.length > 1) output(" these?”");
+	}
+	//else male or taur
+	else
+	{
+		output("\n\n“Of course! That is, if you think you can handle it?” you tease,");
+		if(!pc.isNude()) output(" stripping off and");
+		output(" poking your");
+		
+		if(pc.hasVagina()) output(" [pc.pussies] and");
+		output(" [pc.ass] out teasingly at him.");
+	}
+	
+	output("\n\nFyn grins and strides up, seizing your hips in his powerful hands. Already, you can feel his twin dicks teasingly touching");
+	
+	if(pc.hasVagina() && !pc.isTaur()) output(" against your bared sex");
+	else output(" between your buttocks");
+	output(". The devilish man gives a pointed grind, and you feel his stiffening flesh coax and caress");
+	
+	if(pc.hasVagina()) output(" your womanly lips");
+	else output(" your crevasse");
+	
+	output(". A delicious shiver shoots up from your");
+	
+	if(pc.hasVagina()) output(" loins");
+	else output(" loins");
+	
+	output("—the smallest sampling of the pleasure to come.");
+	output("\n\n“Suck me,” Fyn commands, standing back. His crimson cocks are at half mast; it seems he wants them at full peak! Dropping to your [pc.knees], you inch towards his magnificent tools, greedily inhaling his musky scent. It's even more potent with <i>two</i> dicks; you're rendered positively dizzy by his potent penile aroma. You wrap one hand around his first prick, slowly jerking his foreskin as you kiss and suckle on its twin. The response is immediate—his pricks stiffening and twitching—and you feel a giddy sense of pride. Playing with <i>two</i> is so much more fun than one!");
+	output("\n\n“Enjoying yourself down there?” You hear from above, and give a happy little nod. A large palm is rested on your head, giving you an encouraging stroke. You grin and wrap your [pc.lips] around his swelling glans. With little laps, you tease his flexing cockhole, relishing in his rumbling groans. The flex of his muscular shafts is delicious; you could really suck and tease his twin shafts all day. You shiver as a thick, creamy dollop of pre drools out of the cockhead in your mouth, the other glistening just above your hand. Who said you can't have your cake and eat it too~? You hungrily lap it up, then look up at your double-dicked lover with wide [pc.eyeColor] eyes for approval. He strokes your cheek, and you nuzzle into it with a muffled purr.");
+	output("\n\n“Bend over,” Fyn orders you out of the blue, and you happily obey. Turning around, you raise your rump for him. You moan as his spit-slicked dick sliiiides into your");
+	
+	if(pc.hasVagina()) output(" [pc.pussies]");
+	else output(" [pc.asshole]");
+	
+	output(" and up inside of you, filling you in one swift motion. You groan as his powerful hips press flush against your ass. Inside your");
+	
+	if(pc.hasVagina()) output(" belly");
+	else output(" backside");
+	
+	output(", you can feel his engorged head flexing and straining against your inner walls. Absolute ecstasy swallows your senses, stirred further by every shift of his");
+	
+	if(pc.hasVagina()) output(" pussy-plunged");
+	else output(" butt-buried");
+	
+	output(" manhood.");
+	
+	if(pc.hasVagina()) 
+	{
+		output("\n\nJust when you think it can't get any better, you feel his <i>other</i> fleshy crown pressing against");
+		if(pc.vaginas.length == 1) output(" your sensitive cunt");
+		if(pc.vaginas.length > 1) output(" another pair of your sensitive lower lips");
+		
+		output(". You quiver and moan as he buries both manhoods inside you at once, twitching deliciously in your");
+	
+		if(pc.vaginas.length == 1) output(" pussy and butt");
+		if(pc.vaginas.length > 1) output("own twin pussies");
+		
+		output(". Ohhhh gooddd.... it really <i>is</i> twice the pleasure, just like being double-teamed! You needily push yourself back against his glorious, pleasure-bringing thrusts, your [pc.thighs] quaking and covered in your [pc.girlCumVisc], streaming pussy juices.");
+	}
+	//male or taur
+	else{
+		output("\n\nJust when you think it can't get any better, you feel his <i>other</i> fleshy rod sliding up between your [pc.thighs], until it's resting against your");
+		
+		if(pc.hasCock()) output(" own [pc.biggestCock]");
+		else output(" bare mound");
+		output(". With one dick inside of your rump and another frotting, your muscular lover rides your [pc.ass]. Ohhhh gooddd.... it really <i>is</i> twice the pleasure! You needily push yourself back against his glorious, pleasure-bringing thrusts, your [pc.thighs] quaking with delight.");
+	}
+	
+	//TODO: use Fyn Class to determine cockVolume
+	if (pc.vaginas.length > 1 && !pc.isTaur())
+	{	
+		pc.cuntChange(0, 40, true, true, true);
+		pc.cuntChange(1, 40, true, true, true);
+		//currently broken for null reference pointer, because of ovilium update
+		//pc.loadInCunt();
+	}
+	else 
+	{
+		if(pc.vaginas.length == 1) pc.cuntChange(0, 40, true, true, true);
+		pc.buttChange(40, true, true, true);
+		pc.loadInAss();
+	}
+	
+	output("\n\nWith a loud cry, you utterly cream yourself,");
+	
+	if(pc.hasVagina()) output(" spilling your [pc.girlCum] all over his");
+	if(pc.vaginas.length == 1) output(" cock");
+	if(pc.vaginas.length > 1) output(" cocks");
+	if(pc.hasVagina() && pc.hasCock()) output(" and");
+	if(pc.hasCock()) output(" shooting hot, sticky spunk all over your [pc.belly]");
+	if(!pc.hasVagina() && !pc.hasCock()) output("spasmodically shaking in the throes of your genital-less orgasm");
+	
+	output(". Your cry is turned to a throaty, primal moan as you feel his hot seed shooting inside of your");
+	
+	if(pc.hasVagina()) output(" [pc.pussies], filling");
+	if(pc.vaginas.length == 1) output(" it");
+	if(pc.vaginas.length > 1) output(" them");
+	if(!pc.hasVagina()) output(" [pc.ass], filling it up");
+	
+	output("to the spunk-soaked brim. When he finally pulls out with a loud 'plop', you moan and feel him leaking all down your [pc.legs], though much more of his warmth stays inside of you!");
+	output("\n\n“You're right. Twice the pleasure is twice as good,” Fyn grins, cleaning himself off and redressing. You look at his now cloth-covered loins. Some part of you wants even <i>more</i> of his cock, even though you just took two of them!");
+	
+
+	fynSexed(1);
+	
+	flags["FYN_SEXED_DOUBLE_DICK"] = true;
+	
+	pc.orgasm();
+	processTime(15 + rand(10));
+	
+	clearMenu();
+	addButton(0, "Next", fynMenu);
+}
+
+public function fynSexOrcRavish():void {
+	clearOutput();
+	showFyn();
+	
+	if(flags["FYN_TALKED_ABOUT_SAVEWORDS"] == undefined) 
+	{
+		output("You tell Fyn that you have a rather particular fantasy; one that involves getting forcefully ravished by, well,");
+		
+		if (pc.isBimbo()) output(" the Hulk");
+		else output("an orc");
+		
+		output("! Is that the sort of thing he can do, you ask?");
+		output("\n\nThere's a distinctive glint in Fyn's eyes, “Of course. I can easily grant that sort of wish. But you know, once I get in character, it's <i>very</i> hard to snap me out. For all intents and purposes, I <i>will</i> be a lusty");
+		
+		if (pc.isBimbo()) output(" Hulk");
+		else output(" orc");
+		
+		output(" trying to rape you. So we need a safe word.”");
+		output("\n\n“A safe word?” You muse, spying a dancing book on the table. “How about... tango?”");
+		output("\n\n“Tango will do. Are you sure you want to do this?”");
+		output("\n\nYou nod, cheeks burning. It's always been a fantasy of yours!");
+		
+		flags["FYN_TALKED_ABOUT_SAVEWORDS"] = true;
+	} 
+	else if(flags["FYN_SEXED_ORC_RAVISH"] == 1)
+	{
+		output("You tell Fyn that you have a rather particular fantasy; one that involves getting forcefully ravished by, well,");
+		
+		if(pc.isBimbo()) output(" the Hulk");
+		else output("an orc");
+		
+		output("! Is that the sort of thing he can do, you ask?");
+		output("\n\nThere's a distinctive glint in Fyn's eyes, “Of course. I can easily grant that sort of wish. You remember the safe word, right?”");
+		output("\n\nYou nod. “Tango, yeah? Do you think we'll need it?”");
+		output("\n\n“Of course. Once I get in character, I <i>will</i> be a lusty");
+		
+		if(pc.isBimbo()) output(" Hulk");
+		else output(" orc");
+		
+		output(" trying to rape you. Brace yourself, " + pc.mf("man", "woman") + ".");
+		output("\n\nYou nod, cheeks burning. It seems your fantasy is going to come true again!");
+	} else 
+	{
+		output("You ask Fyn if he can transform into an orc again and ravish you. With a glint in his eyes, he nods. “Of course. It was a <i>lot</i> of fun last time.”");
+	}
+	
+	output("\n\nThe polymorph strips off his shirt and stands there. He closes his eyes and brings his closed fists to his waist. His head lowers, facial expression covered by his hair. His taut muscles then begin to shift and move. They begin to expand, becoming bulkier and more prominent. His pectorals protrude until they look like they belong on a professional body-builder... or more accurately, some sort of primal, tribal warrior. Similar changes occur down at his abs, arms, and legs, until the muscular man is nearly twice the size he was before—it's incredible to watch! All of his skin begins to change at once, shifting to an olive green. His dark hair pulls back into his scalp");
+	
+	if(!pc.isBimbo()) output(", raising the curtain on the two pointed tusks he now has jutting out from his fat lower lip");
+	else output(". You are now standing before what is unmistakably");
+	
+	if(pc.isBimbo()) output(" a crime-fighting superhero");
+	else output(" a bulky behemoth of an orc");
+	output(", with a whopping bulge in his torn pants to match.");
+	
+	output(" He narrows his eyes. A forceful shove. You're knocked back and sprawling on to the carpet. As you topple ass over head, you let out a surprised shout. W-what's going on?");
+	if(!pc.isNude()) output(" When everything stops moving, you feel the fabric of your clothing being forcibly stripped off.");
+	
+	output(" You shiver, buck naked and upside down, your [pc.knees] somewhere near your cheeks! A fierce slap is delivered to your bare buttocks, and you squeal in surprise. It stings—but more than that, it's embarrassing as hell!");
+	output("\n\n“Your [pc.skinColor] ass is");
+	
+	if(pc.isBimbo()) output(" the Hulk's now");
+	
+	else output(" mine");
+	output(" now, bitch,” the");
+	
+	if(pc.isBimbo()) output(" green");
+	else output(" orcish");
+	output(" man grunts. His thick, powerful digits squeeze your stinging butt. His property?! You gasp as he suddenly yanks you by your [pc.legs]. You're left on your back, looking up at his fierce yellow eyes and");
+	
+	if(pc.isBimbo()) output(" big");
+	else output(" tusked");
+	output(" lips, curled in a snarl. And—oh fuck—you can see his massive green tool now, but it's pink on top with pearly lumps. “Time to get butt-bred.");
+	
+	if(pc.isBimbo()) output(" Hulk smash puny hole!”");
+	else output(" For the goddamn horde.”");
+	
+	output("\n\nDespite your protests, you're pinned down with a powerful hand, helpless as he");
+	if(pc.hasLegs() && !pc.isNaga()) output(" spreads your legs and");
+	output(" positions himself right at your poor, quivering buttocks. With a forceful press, he pushes himself between your quivering cheeks, worming his massive dick right up until it's pressing at your twitching pucker. You groan as his contoured cockhead spreads your fleshy ring, insistently pushing inch by inch into your rectum. Fuuuck, he's so big");
+	if(pc.hasVagina()) output(", and he's not even using your [pc.pussiesNoun]");
+	
+	output("! You bite your lower lip as he caresses");
+	if(pc.hasCock()) output(" your prostate. His massive tool rocks and rubs against your sweet spot, causing your [pc.cocks] to slap instinctively against your stomach!");
+	else output(" your bowels with his extremely stiff cock.");
+	
+	//higher cockVolumn than in Fyn class because of orc transform
+	pc.buttChange(150, true, true, true);
+	pc.loadInAss();
+	
+	output("\n\n“Holding on, slut?” He grunts. You nod, reaching up and clinging to a nearby pillow. Just in time! One powerful thrust of his hips later, and every inch of your parted rump is stuffed with");
+	
+	if(pc.isBimbo()) output(" banner bacon");
+	else output(" orcish cock");
+	
+	output("! You whimper with delight; as his primal prick stretches your inner rump, pleasure <i>explodes</i> out into every inch of your body. Your [pc.legs] can't stop shaking! All you can do is moan and squeal as he thoroughly and possessively fucks your [pc.skinColor] butt, breeding you like the bitch you are!");
+	output("\n\nWith each lusty thrust of his powerful hips, you feel yourself answering back, needily pressing your posterior towards and onto his turgid rod. His cockhead gets deeper, swells larger, caressing inside of you, driving you wild! You <i>know</i> you're going to be the first to come; just looking up at his sexy, muscular body thrusting up against and claiming your [pc.ass] is getting your");
+	
+	if(pc.hasCock()) output(" [pc.cocksLight] hard");
+	if(pc.hasCock() && pc.hasVagina()) output(" and your");
+	if(pc.hasVagina()) output(" [pc.pussies] wet");
+	if(!pc.hasCock() && !pc.hasVagina()) output("gears going");
+	
+	output(". You moan and relish in his liberal fucking of your [pc.asshole], [pc.thighs] quaking in delight. At last, you can take it no more, as an explosion of sheer bliss sweeps through you sweat-covered body. With a loud cry, you utterly cream yourself on his girthy cock,");
+	
+	if(pc.hasCock()) output(" shooting your own [pc.cumVisc] spunk all over your [pc.face]");
+	if(pc.hasCock() && pc.hasVagina()) output(" and");
+	if(pc.hasVagina()) 
+	{
+		if(pc.isSquirter()) output(" [pc.girlCumNoun] in a [pc.girlCumColor] stream high up in the air");
+		else output("drooling [pc.girlCum] down your [pc.clits] and [pc.belly]");
+	}
+	if(!pc.hasCock() && !pc.hasVagina()) output("clenching the cushion above you");
+	
+	output(". Your quaking buttocks clench his girthy orchood, and with a guttural cry, you feel him flexing and shooting pure warmth deep inside of your rectum, filling it with his slick spunk.");
+	
+	output("\n\nWhen he pulls out, you can feel it lewdly rolling out and down your butt-crack and back. You blush furiously, reaching up and spreading your [pc.ass]. Your green-skinned lover takes one look at your parted, cum-smeared pucker and looks riled up again! Grabbing his stiffening rod, he plunges it back into your sloppy hole. Buried once more up to the hilt, he begins slapping enthusiastically against your already worn buttocks. After already cumming, you're overloaded with such <i>intense</i> sensory feedback—it's too much for you to handle! You babble and whimper in delight. Rolling back your eyes and drooling down your cheek, you're a helpless passenger swept up in a storm of pleasure. Your mind is utterly swallowed by the tidal forces, yet your body instinctively bucks back against the rutting beast on its own. You cum <i>again</i>, shivering and twitching, your upper body limp and lower body spasming. It doesn't stop him! He has his way with you until you have came more times than you can count, and at last, <i>he's</i> entirely spent!");
+	output("\n\nWhen you finally come to, you feel something soft beneath you. Your ass is unmistakably sore; even the slightest wiggle makes you wince! At the same time, it's packed full of gooey warmth. Every inch of your [pc.skinFurScalesNoun] is singing with happiness. You are definitely one well bred slut! A dopey grin crosses your [pc.lips] as you swiftly fall back into slumber... you're going to need to rest this one off...");
+	output("\n\n<b>... A few hours later ... </b>");
+	output("\n\nThere's a poking at your cheek. You mumble and wave it away. There's a rich chuckle. Opening a single eye, you see a scarlet face staring back at you. Fyn? It seems he's transformed back. You realise you're on the couch, underneath a blanket. Your polymorph lover is drinking what seems to be a shake of some kind, though there's a lot of empty plates before him.");
+	output("\n\n“You're awake. Guess we both had quite the recovery time,” he remarks, sipping from the straw. “Your");
+	
+	if(pc.isNude()) output(" things");
+	else output(" clothes");
+	
+	output(" are there. I didn't want to wake you. You looked like you needed the rest.”");
+	output("\n\nYou thank him, and after you've mustered the energy, slip your stuff back on. What a fucking! You rub your butt again, a dopey smile on your face. Geez, you're still leaking down your [pc.legs]!");
+	
+	fynSexed(1);
+	
+	if(flags["FYN_SEXED_ORC_RAVISH"] == undefined) flags["FYN_SEXED_ORC_RAVISH"] = 1;
+	else flags["FYN_SEXED_ORC_RAVISH"]++;
+	
+	pc.orgasm();
+	processTime(30 + rand(15));
+	
+	clearMenu();
+	addButton(0, "Next", fynMenu);
+}


### PR DESCRIPTION
First implementation of residential deck on Tavros (texts by JimTermic)

Includes:
- New rooms (accessed by going up in the elevator on Tavros
- Notice board in one of the rooms with messags from residents
- NPCs Fyn + Aina