### PR TITLE
Accessories and perks that increase accuracy don't actually increase accuracy.

### DIFF
--- a/classes/Engine/Combat/combatMiss.as
+++ b/classes/Engine/Combat/combatMiss.as
@@ -11,7 +11,7 @@ package classes.Engine.Combat
 	 */
 	public function combatMiss(attacker:Creature, target:Creature, overrideAttack:Number = -1, missModifier:Number = 1):Boolean 
 	{
-		if (overrideAttack == -1) overrideAttack = attacker.meleeWeapon.attack;
+		if (overrideAttack == -1) overrideAttack = attacker.attack(true);
 		
 		if(rand(100) + attacker.physique()/5 + overrideAttack - target.reflexes()/5 < 10 * missModifier && !target.isImmobilized()) 
 		{

--- a/classes/Engine/Combat/rangedCombatMiss.as
+++ b/classes/Engine/Combat/rangedCombatMiss.as
@@ -9,7 +9,7 @@ package classes.Engine.Combat
 	 */
 	public function rangedCombatMiss(attacker:Creature, target:Creature, overrideAttack:Number = -1, missModifier:Number = 1):Boolean 
 	{
-		if (overrideAttack == -1) overrideAttack = attacker.rangedWeapon.attack;
+		if (overrideAttack == -1) overrideAttack = attacker.attack(false);
 		
 		//Immune!
 		if (target.hasPerk("Ranged Immune")) return true;


### PR DESCRIPTION
combatMiss and rangedCombatMiss use the attack value of the weapon only (`attacker.meleeWeapon.attack` or `attacker.rangedWeapon.attack`), and not the summed value as in `Creature.attack(melee: Boolean)`

