### PR TITLE
Code cleanup and tweaks

### DIFF
--- a/classes/Creature.as
+++ b/classes/Creature.as
@@ -2779,9 +2779,6 @@
 			if(!isCrotchGarbed()) return true;
 			return ((armor is EmptySlot || armor.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_FULL) || armor.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_ASS)) && (lowerUndergarment is EmptySlot || lowerUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_FULL) || lowerUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_ASS)));
 		}
-		public function isGroinCovered(): Boolean {
-			return isCrotchGarbed();
-		}
 		public function isChestCovered(): Boolean {
 			if(hasStatusEffect("Temporary Nudity Cheat")) return false;
 			else if(armor is EmptySlot && upperUndergarment is EmptySlot) return false;

--- a/classes/VaginaClass.as
+++ b/classes/VaginaClass.as
@@ -68,9 +68,9 @@
 			
 			var currLoose:Number = loosenessRaw + loosenessMod;
 			
-			if (currLoose < 1)
+			if (currLoose < 0.5)
 			{
-				return 1;
+				return 0.5;
 			}
 			else if (currLoose > 5) // or so :V
 			{

--- a/includes/game.as
+++ b/includes/game.as
@@ -1811,13 +1811,15 @@ public function processTime(arg:int):void {
 					else pc.vaginas[x].shrinkCounter = 0;
 					//Reset for this cunt.
 					tightnessChanged = false;
-					if(pc.vaginas[x].loosenessRaw < 2) {}
-					else if(pc.vaginas[x].loosenessRaw >= 5 && pc.vaginas[x].shrinkCounter >= 60) tightnessChanged = true;
+					if(pc.vaginas[x].loosenessRaw >= 5 && pc.vaginas[x].shrinkCounter >= 60) tightnessChanged = true;
 					else if(pc.vaginas[x].loosenessRaw >= 4 && pc.vaginas[x].shrinkCounter >= 96) tightnessChanged = true;
 					else if(pc.vaginas[x].loosenessRaw >= 3 && pc.vaginas[x].shrinkCounter >= 132) tightnessChanged = true;
 					else if(pc.vaginas[x].loosenessRaw >= 2 && pc.vaginas[x].shrinkCounter >= 168) tightnessChanged = true;
+					else if(pc.vaginas[x].loosenessRaw >= pc.vaginas[x].minLooseness && pc.vaginas[x].shrinkCounter >= 204) tightnessChanged = true;
 					if(tightnessChanged) {
 						pc.vaginas[x].loosenessRaw--;
+						if (pc.vaginas[x].loosenessRaw < pc.vaginas[x].minLooseness)
+							pc.vaginas[x].loosenessRaw = pc.vaginas[x].minLooseness;
 						msg += "\n\n<b>Your";
 						if(pc.totalVaginas() > 1) msg += " " + num2Text2(x+1);
 						msg += " " + pc.vaginaDescript(x) + " has recovered from its ordeals, tightening up a bit.</b>";
@@ -1831,13 +1833,15 @@ public function processTime(arg:int):void {
 			else pc.ass.shrinkCounter = 0;
 			//Reset for this cunt.
 			tightnessChanged = false;
-			if(pc.ass.loosenessRaw < 2) {}
-			else if(pc.ass.loosenessRaw >= 5 && pc.ass.shrinkCounter >= 12) tightnessChanged = true;
+			if(pc.ass.loosenessRaw >= 5 && pc.ass.shrinkCounter >= 12) tightnessChanged = true;
 			else if(pc.ass.loosenessRaw >= 4 && pc.ass.shrinkCounter >= 24) tightnessChanged = true;
 			else if(pc.ass.loosenessRaw >= 3 && pc.ass.shrinkCounter >= 48) tightnessChanged = true;
 			else if(pc.ass.loosenessRaw >= 2 && pc.ass.shrinkCounter >= 72) tightnessChanged = true;
+			else if(pc.ass.loosenessRaw >= pc.ass.minLooseness && pc.ass.shrinkCounter >= 96) tightnessChanged = true;
 			if(tightnessChanged) {
 				pc.ass.loosenessRaw--;
+				if (pc.ass.loosenessRaw < pc.ass.minLooseness)
+					pc.ass.loosenessRaw = pc.ass.minLooseness;
 				if(pc.ass.loosenessRaw <= 4) eventBuffer += "\n\n<b>Your " + pc.assholeDescript() + " has recovered from its ordeals and is now a bit tighter.</b>";
 				else eventBuffer += "\n\n<b>Your " + pc.assholeDescript() + " recovers from the brutal stretching it has received and tightens up.</b>";
 			}
@@ -1879,17 +1883,9 @@ public function processTime(arg:int):void {
 				//Unlock dat shiiit
 				if(flags["HOLIDAY_OWEEN_ACTIVATED"] == undefined && (isHalloweenish() || rand(100) == 0)) eventQueue.push(hollidayOweenAlert);
 				if(pc.hasPerk("Honeypot") && days % 3 == 0) honeyPotBump();
-				//Exhibitionism reduction!
-				if
-				(	!(pc.armor is EmptySlot)
-				&&	!(pc.lowerUndergarment is EmptySlot || pc.lowerUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_FULL) || pc.lowerUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_GROIN) || pc.lowerUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_ASS))
-				&&	!(pc.upperUndergarment is EmptySlot || pc.upperUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_FULL) || pc.upperUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_CHEST))
-				)
-				{
-					if(pc.isChestExposed() && pc.isCrotchExposed() && pc.isAssExposed())
-						{ /* No reduction for a full set of exposed clothing! */ }
-					else pc.exhibitionism(-0.5);
-				}
+				//Exhibitionism reduction! Reduces exhibition if chest, crotch and ass are not all exposed
+				if(!(pc.isCrotchExposed() && pc.isAssExposed() && pc.isChestExposed()))
+					pc.exhibitionism(-0.5);
 				// New Texas cockmilker repair cooldown.
 				if (flags["MILK_BARN_COCKMILKER_BROKEN"] == undefined && flags["MILK_BARN_COCKMILKER_REPAIR_DAYS"] != undefined)
 				{

--- a/includes/myrellion/cockvines.as
+++ b/includes/myrellion/cockvines.as
@@ -469,7 +469,7 @@ public function adultCockvinePCLoses():void
 	}
 
 	output("\n\nOther tentacles are");
-	if (pc.isGroinCovered()) output(" burrowing busily through your [pc.lowerGarment],");
+	if (pc.isCrotchGarbed()) output(" burrowing busily through your [pc.lowerGarment],");
 	else if (pc.isBiped()) output(" coiling themselves up around your [pc.thighs],");
 	output(" blindly seeking out the fresh, fertile holes they know are there.");
 	if (pc.hasVagina())


### PR DESCRIPTION
Tweaked the Vagina class to return the tightness if it is between 0.5
and 1 since Mighty Tight can lower the minimum tightness to 0.5.

Tweaked the game.as to allow a vagina or ass to recover to the minimum
looseness. It previously stopped checking after the raw looseness
dropped below 2.

Changed the logic for exhibition decrease to be more concise and clear.

Removed a function from the creature class since it was only called in
one place and all the function did was return the value of another
function.