### PR TITLE
Implement Circumscriber and Turtleneck

### DIFF
--- a/classes/Characters/Gene.as
+++ b/classes/Characters/Gene.as
@@ -8,6 +8,8 @@
 	import classes.Items.Transformatives.Bovinium;
 	import classes.Items.Transformatives.BumpyRoad;
 	import classes.Items.Transformatives.MinoCharge;
+	import classes.Items.Transformatives.Circumscriber;
+	import classes.Items.Transformatives.Turtleneck;
 	import classes.kGAMECLASS;
 	import classes.Engine.Utility.rand;
 	
@@ -31,6 +33,8 @@
 			inventory.push(new EasyFit());
 			inventory.push(new Chocolac());
 			inventory.push(new BumpyRoad());
+			inventory.push(new Circumscriber());
+			inventory.push(new Turtleneck());
 			
 			this.typesBought = [];
 			

--- a/classes/Items/Transformatives/Circumscriber.as
+++ b/classes/Items/Transformatives/Circumscriber.as
@@ -1,0 +1,250 @@
+package classes.Items.Transformatives
+{
+	import classes.Engine.Interfaces.*;
+	import classes.Engine.Utility.formatFloat;
+	import classes.Engine.Utility.num2Ordinal;
+	import classes.Engine.Utility.rand;
+	import classes.ItemSlotClass;
+	import classes.GLOBAL;
+	import classes.Creature;
+	import classes.kGAMECLASS;	
+	import classes.Characters.PlayerCharacter;
+	import classes.GameData.TooltipManager;
+	import classes.StringUtil;
+	import classes.Util.InCollection;
+	
+	public class Circumscriber extends ItemSlotClass
+	{
+		
+		public function Circumscriber()
+		{
+			_latestVersion = 1;
+			
+			quantity = 1;
+			stackSize = 10;
+			type = GLOBAL.DRUG;
+			shortName = "Circumser";
+			longName = "jar of Circumscriber cream";
+			
+			TooltipManager.addFullName(shortName, StringUtil.toTitleCase(longName));
+			
+			description = "a jar of cream called ‘Circumscriber’";
+			tooltip = "The label of this Blue Crab product as an ancient, sepia style drawing of a scribe with a stylized scar after he just finished writing “Circumscriber” on a scroll. Inside there is a glittery orange cream filled with microsurgeons, outdated but still endorsed by several health agencies, that when applied to a penis can erase a sheath, a foreskin or result in negligible decreases in its length or thickness.";
+			
+			TooltipManager.addTooltip(shortName, tooltip);
+			
+			attackVerb = "";
+			
+			basePrice = 3000;
+			
+			version = _latestVersion;
+		}
+		
+		//METHOD ACTING!
+		override public function useFunction(target:Creature, usingCreature:Creature = null):Boolean
+		{
+			kGAMECLASS.clearOutput();
+			kGAMECLASS.showName("CIRCUMSCRIBER");
+			author("Lashcharge");
+			
+			if(target is PlayerCharacter)
+			{
+				if(!target.hasCock())
+				{
+					if(!kGAMECLASS.infiniteItems()) quantity++;
+					kGAMECLASS.output("Unfortunately, you do not have any penises to apply this on.");
+					kGAMECLASS.output("\n\nYou put the item back in your inventory.");
+					return false;
+				}
+				
+				var i:int = -1;
+				var x:int = 0;
+				var btnSlot:int = 0;
+				
+				if(target.cocks.length == 1)
+				{
+					cockTF([target, 0]);
+					return true;
+				}
+				
+				kGAMECLASS.output("You have more than one penis. Which one will you apply Circumscriber to?\n");
+				
+				kGAMECLASS.clearMenu();
+				for(i = 0; i < target.cocks.length; i++)
+				{
+					output("\n<b>" + StringUtil.capitalize(num2Ordinal(i + 1)) + " Cock:</b>");
+					if(target.cocks[i].cockFlags.length > 0)
+					{
+						for(x = 0; x < target.cocks[i].cockFlags.length; x++)
+						{
+							output(" " + GLOBAL.FLAG_NAMES[target.cocks[i].cockFlags[x]] + ",");
+						}
+					}
+					if(target.cocks[i].cockColor != "") output(" " + StringUtil.toDisplayCase(target.cocks[i].cockColor) + ",");
+					output(" " + GLOBAL.TYPE_NAMES[target.cocks[i].cType]);
+					if(target.cocks[i].cLength() > 0) output(", " + formatFloat(target.cocks[i].cLength(), 3) + " in long");
+					if(target.cocks[i].thickness() > 0) output(", " + formatFloat(target.cocks[i].thickness(), 3) + " in thick");
+					
+					addButton(btnSlot, "Cock " + (i + 1), cockTF, [target, i], StringUtil.capitalize(num2Ordinal(i + 1)) + " Cock", "Use this on your [pc.cock " + i + "].");
+					btnSlot++;
+				}
+				return true;
+			}
+			else
+			{
+				kGAMECLASS.output(target.capitalA + target.short + " applies the Circumscriber cream but to no effect.");
+			}
+			return false;
+		}
+		
+		private function cockTF(arg:Array):void
+		{
+			clearOutput();
+			kGAMECLASS.showName("CIRCUMSCRIBER");
+			author("Lashcharge");
+			
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+			var hasUnderwear:Boolean = (target.hasLowerGarment() && !target.lowerUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_FULL) && !target.lowerUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_GROIN));
+			
+			output("You read the instructions and open the scribe-themed jar");
+			if(!target.isCrotchExposed())
+			{
+				output(", followed by");
+				if(target.hasArmor()) output(" removing your [pc.armor]");
+				if(hasUnderwear)
+				{
+					if(target.hasArmor()) output(" and");
+					output(" dropping your [pc.lowerUndergarment] to the floor");
+				}
+			}
+			output(". You scoop a large dollop of the orange glittery cream and carefully smear every inch of your [pc.cockNoun " + i + "] in it");
+			if (target.cocks[i].hasFlag(GLOBAL.FLAG_KNOTTED) || target.cocks[i].hasFlag(GLOBAL.FLAG_SHEATHED))
+			{
+				output(", especially");
+				if(target.cocks[i].hasFlag(GLOBAL.FLAG_KNOTTED)) output(" behind the [pc.knot " + i + "]");
+				if(target.cocks[i].hasFlag(GLOBAL.FLAG_KNOTTED) && target.cocks[i].hasFlag(GLOBAL.FLAG_SHEATHED)) output(" and");
+				if(target.cocks[i].hasFlag(GLOBAL.FLAG_SHEATHED)) output(" within the [pc.sheath " + i + "]");
+				if(target.totalGenitals() > 1) output(" while trying to avoid your other genital");
+				if(target.totalGenitals() > 2) output("s");
+			}
+			output(". You apply the rest around and on your [pc.cockHead " + i + "]");
+			if(target.cocks[i].hasFlag(GLOBAL.FLAG_FORESKINNED)) output(", pulling down your foreskin, coating its insides and releasing it, letting it spread the cream more thoroughly by itself");
+			output(". As you wait for the transformation, the orange cream dries up and the aphrodisiacs kick in as your [pc.cock " + i + "] stiffens into a bulging erection, covered in gray glitter.");			
+			
+			output("\n\n");
+			if(target.cocks[i].hasFlag(GLOBAL.FLAG_FORESKINNED) && rand(2) == 0) foreskinTF([target, i]);
+			else if(target.cocks[i].hasFlag(GLOBAL.FLAG_SHEATHED)) sheathTF([target, i]);
+			else if(target.cocks[i].cLengthRaw > 5 && rand(2) == 0) cockLenghtTF([target, i]);
+			else if(target.cocks[i].cThicknessRatioRaw > 0.1) cockThickTF([target, i]);
+			else dudTF([target, i]);
+		}
+		
+		private function dudTF(arg:Array):void
+		{
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+			
+			output("Aside from a few short tingles along your [pc.cockNoun " + i + "], nothing really happens... what a waste.");
+			target.lust(100);
+			
+			kGAMECLASS.clearMenu();
+			kGAMECLASS.addButton(0,"Next",kGAMECLASS.useItemFunction);
+		}
+		
+		private function foreskinTF(arg:Array):void
+		{
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+
+			//Target penis loses a foreskin flag if it has one. 
+			output("You feel pinching on your foreskin as the gray microsurgeons crawl all over your shaft, gathering around the ridged band, touching and triggering every sensitive nerve on one of your most innervated parts. Their delicate work stretches the elastic band apart, leaving a slackened sleeve of skin hanging around your [pc.cockHead " + i + "]. Some of the tiny machines crawl inside your prepuce, while the rest spread around your shaft. They position themselves in the form of rings around your [pc.skinColor] shaft, more abundant in where your foreskin is loose and less frequent the closer they are to its base and frantically move up and down across it. They never break formation and only turn back when they reach another ring, turning the skin tighter as it starts to disappear into your shaft.");
+			output("\n\nThankfully you seem to become less sensitive with time, the itchiness disappearing together with your extranous nerves. The foreskin turns into a bump as they get closer to finishing their job, some of the rings already gathering at what remains of your frenulum and erasing the last bits of the elastic tissue. Soon there is nothing left but a straight line that runs across your cumvein to the urethra.");
+			output("\n\nYou are left with a ");
+			{
+				if (InCollection(target.cocks[i].cType, [GLOBAL.TYPE_BEE, GLOBAL.TYPE_VANAE, GLOBAL.TYPE_ANEMONE, GLOBAL.TYPE_SIREN, GLOBAL.TYPE_TENTACLE, GLOBAL.TYPE_HUMAN]) || !target.cocks[i].cockColor == "mottled pink and black") output("two-toned dick, the vibrant [pc.cockColor " + i + "] head accentuated by your [pc.skinColor]-colored shaft");
+				else output("[pc.cockColor " + i + "] dick, completely uniform in color");
+			}
+			output(". But it seems like the work of the little machines is not over, as they spread around your cock-head and give it a thorough rubbing. It seems like your new-found insensitivity is helping, as you barely feel them turning your [pc.cockHead " + i + "] a little bit more rugged than it used to be."); 
+			output("\n\nAs the machines flake off and disappear into the ground below, you sigh in relief, realizing you can now rub one out. You wrap your hands around your [pc.cock " + i + "] and try to masturbate, but you discover that, with no gliding action and extra sensitivity to help, you are going to have to be rougher than you were before. It's a stiff,");
+			{
+				if(target.cocks[i].hasFlag(GLOBAL.FLAG_LUBRICATED)) output(" slick");
+				if(target.cocks[i].hasFlag(GLOBAL.FLAG_STICKY)) output(" sticky");
+				else output(" dry");
+			}
+			output(" rod of raw meat that you must force into orgasm. With a quick and rough pace, you grind across your shaft, trying to get as much sensation out of it as you can possibly get. ");
+			{
+				if(target.cocks[i].hasFlag(GLOBAL.FLAG_LUBRICATED)) output("Your slick, lubricated dick is really helping with bringing yourself to the edge");
+				if(target.cocks[i].hasFlag(GLOBAL.FLAG_STICKY)) output("Your sticky, oil-covered dick, is definitely not helping with this, forcing you to be even rougher than you thought you could tolerate");
+				else output("Delightedly, you start to ooze with pre-cum, the extra lubrication really helping with bringing yourself to the edge");
+			}
+			output(". It takes a while to reach your orgasm and, with little notice, it explodes in your mind sending waves of lust throughout your body. Your ejaculate shoots unimpeded straight into the floor, before tapering off into oozing [pc.cum] from your unsullied dick. <b>Your [pc.cock " + i + "] has lost its foreskin!</b>");
+		
+			target.cocks[i].delFlag(GLOBAL.FLAG_FORESKINNED);
+			target.orgasm();
+
+			kGAMECLASS.clearMenu();
+			kGAMECLASS.addButton(0,"Next",kGAMECLASS.useItemFunction);
+		}
+		
+		private function sheathTF(arg:Array):void
+		{
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+
+			//Target penis loses a sheath flag if has one. 
+			output("You feel itchy as the little gray machines crawl all over your [pc.sheath " + i + "] and into it from all across your [pc.cock " + i + "], giving it a gray metallic tint");
+			{
+				if (target.skinType == GLOBAL.SKIN_TYPE_FUR) output(". One by one the hairs on your sheath fall off");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_FEATHERS) output(". One by one the feathers on your sheath fall off");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_SCALES) output(". One by one the scales on your sheath fall off");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_CHITIN) output(". You hear the chitinous covering of your sheath cracking off and turning into dust as it falls on the ground");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_BARK) output(". You hear the arboreal covering of your sheath cracking off and turning into dust as it falls on the ground");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_GOO) output(". Your amorphous sheath feels weird as it loses its translucence");
+			}
+			output(". Slowly, you can see your sheath recede into the skin of your crotch, until it evens out and all that remains is the outline of the slit tight around the base of your cock. Then the machines loosen that ring, uncurling it until it completely disappears into your body.");
+			output("\n\nWith their job done the machines fall off you and disappear into the air, leaving your cock ");
+			{
+				if(target.cocks[i].hasFlag(GLOBAL.FLAG_FORESKINNED)) output("with a comforting foreskin around it. With no distinct line dividing the [pc.skinColor] of your cock from the skin of your crotch");
+				else output("bare of any loose skin, with your [pc.cockHead " + i + "] fully exposed");
+			}
+			output(". There must have been a weird anaphrodisiac somewhere in there because you're rapidly losing your erection, but unlike before it now hangs completely flaccid against your [pc.sack]. <b>Your [pc.cock " + i + "] has lost its sheath!</b>");
+			
+			target.cocks[i].delFlag(GLOBAL.FLAG_SHEATHED);
+			target.lust(30);
+			
+			kGAMECLASS.clearMenu();
+			kGAMECLASS.addButton(0,"Next",kGAMECLASS.useItemFunction);
+		}
+		
+		private function cockLenghtTF(arg:Array):void
+		{
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+
+			//Target penis gains 0.1 of length.
+			output("The gray specks are unable to complete their programming and promptly fall off your prick, yet you still feel <i>something</i> going on down there. The tell-tale sensation of nanomachines in action and your aphrodisiac-powered boner helps you figure out what's happening. To your chagrin, it seems <b>that your [pc.cock " + i + "] has lost a bit of its length.</b>");
+			
+			target.cocks[i].cLengthRaw -= 0.1;
+			target.lust(15);
+			
+			kGAMECLASS.clearMenu();
+			kGAMECLASS.addButton(0,"Next",kGAMECLASS.useItemFunction);
+		}
+		
+		private function cockThickTF(arg:Array):void
+		{
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+
+			//Target penis gains 0.1 of thickness ratio.
+			output("The tiny machines skitter around your [pc.cock " + i + "], falling off it one by one as their programming fails. Not wanting to let a good boner go to waste, you decide to play with yourself for a bit. You only stop when you notice <b>that your [pc.cock " + i + "] has become a little thinner within your grasp.</b>"); 
+			
+			target.cocks[i].cThicknessRatioRaw -= 0.1;
+			target.lust(15);
+			
+			kGAMECLASS.clearMenu();
+			kGAMECLASS.addButton(0,"Next",kGAMECLASS.useItemFunction);
+		}
+	}
+}

--- a/classes/Items/Transformatives/Turtleneck.as
+++ b/classes/Items/Transformatives/Turtleneck.as
@@ -1,0 +1,231 @@
+package classes.Items.Transformatives
+{
+	import classes.Engine.Interfaces.*;
+	import classes.Engine.Utility.formatFloat;
+	import classes.Engine.Utility.num2Ordinal;
+	import classes.Engine.Utility.rand;
+	import classes.ItemSlotClass;
+	import classes.GLOBAL;
+	import classes.Creature;
+	import classes.kGAMECLASS;	
+	import classes.Characters.PlayerCharacter;
+	import classes.GameData.TooltipManager;
+	import classes.StringUtil;
+	import classes.Util.InCollection;
+	
+	public class Turtleneck extends ItemSlotClass
+	{
+		
+		public function Turtleneck()
+		{
+			_latestVersion = 1;
+			
+			quantity = 1;
+			stackSize = 10;
+			type = GLOBAL.DRUG;
+			shortName = "T.Neck";
+			longName = "jar of Turtleneck cream";
+			
+			TooltipManager.addFullName(shortName, StringUtil.toTitleCase(longName));
+			
+			description = "a jar of cream called ‘Turtleneck’";
+			tooltip = "The label of this Blue Crab product depicts a handsome spy wearing a black turtleneck and spy goggles, with “Turtleneck” written on his sleeve. Inside there is a glittery blue cream filled with microsurgeons, outdated but still endorsed by several health agencies, that when applied to a penis can grow a sheath, a foreskin or result in negligible increases in its length or thickness.";
+			
+			TooltipManager.addTooltip(shortName, tooltip);
+			
+			attackVerb = "";
+			
+			basePrice = 3000;
+			
+			version = _latestVersion;
+		}
+		
+		//METHOD ACTING!
+		override public function useFunction(target:Creature, usingCreature:Creature = null):Boolean
+		{
+			kGAMECLASS.clearOutput();
+			kGAMECLASS.showName("TURTLENECK");
+			author("Lashcharge");
+			
+			if(target is PlayerCharacter)
+			{
+				if(!target.hasCock())
+				{
+					if(!kGAMECLASS.infiniteItems()) quantity++;
+					kGAMECLASS.output("Unfortunately, you do not have any penises to apply this on.");
+					kGAMECLASS.output("\n\nYou put the item back in your inventory.");
+					return false;
+				}
+				
+				var i:int = -1;
+				var x:int = 0;
+				var btnSlot:int = 0;
+				
+				if(target.cocks.length == 1)
+				{
+					cockTF([target, 0]);
+					return true;
+				}
+				
+				kGAMECLASS.output("You have more than one penis. Which one will you apply Turtleneck to?\n");
+				
+				kGAMECLASS.clearMenu();
+				for(i = 0; i < target.cocks.length; i++)
+				{
+					output("\n<b>" + StringUtil.capitalize(num2Ordinal(i + 1)) + " Cock:</b>");
+					if(target.cocks[i].cockFlags.length > 0)
+					{
+						for(x = 0; x < target.cocks[i].cockFlags.length; x++)
+						{
+							output(" " + GLOBAL.FLAG_NAMES[target.cocks[i].cockFlags[x]] + ",");
+						}
+					}
+					if(target.cocks[i].cockColor != "") output(" " + StringUtil.toDisplayCase(target.cocks[i].cockColor) + ",");
+					output(" " + GLOBAL.TYPE_NAMES[target.cocks[i].cType]);
+					if(target.cocks[i].cLength() > 0) output(", " + formatFloat(target.cocks[i].cLength(), 3) + " in long");
+					if(target.cocks[i].thickness() > 0) output(", " + formatFloat(target.cocks[i].thickness(), 3) + " in thick");
+					
+					addButton(btnSlot, "Cock " + (i + 1), cockTF, [target, i], StringUtil.capitalize(num2Ordinal(i + 1)) + " Cock", "Use this on your [pc.cock " + i + "].");
+					btnSlot++;
+				}
+				return true;
+			}
+			else
+			{
+				kGAMECLASS.output(target.capitalA + target.short + " applies the Turtleneck cream but to no effect.");
+			}
+			return false;
+		}
+		
+		private function cockTF(arg:Array):void
+		{
+			clearOutput();
+			kGAMECLASS.showName("TURTLENECK");
+			author("Lashcharge");
+			
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+			var hasUnderwear:Boolean = (target.hasLowerGarment() && !target.lowerUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_FULL) && !target.lowerUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_GROIN));
+			
+			output("You read the instructions and open the gangster-themed jar");
+			if(!target.isCrotchExposed())
+			{
+				output(", followed by");
+				if(target.hasArmor()) output(" removing your [pc.armor]");
+				if(hasUnderwear)
+				{
+					if(target.hasArmor()) output(" and");
+					output(" dropping your [pc.lowerUndergarment] to the floor");
+				}
+			}
+			output(". You scoop a large dollop of the blue glittery cream and carefully smear every inch of your [pc.cockNoun " + i + "] in it");
+			if (target.cocks[i].hasFlag(GLOBAL.FLAG_KNOTTED) || target.cocks[i].hasFlag(GLOBAL.FLAG_SHEATHED))
+			{
+				output(", especially");
+				if(target.cocks[i].hasFlag(GLOBAL.FLAG_KNOTTED)) output(" behind the [pc.knot " + i + "]");
+				if(target.cocks[i].hasFlag(GLOBAL.FLAG_KNOTTED) && target.cocks[i].hasFlag(GLOBAL.FLAG_SHEATHED)) output(" and");
+				if(target.cocks[i].hasFlag(GLOBAL.FLAG_SHEATHED)) output(" within the [pc.sheath " + i + "]");
+				if(target.totalGenitals() > 1) output(" while trying to avoid your other genital");
+				if(target.totalGenitals() > 2) output("s");
+			}
+			output(". You apply the rest around and on your [pc.cockHead " + i + "]");
+			if(target.cocks[i].hasFlag(GLOBAL.FLAG_FORESKINNED)) output(", pulling down your foreskin, coating its insides and releasing it, letting it spread the cream more thoroughly by itself");
+			output(". As you wait for the transformation, the blue cream dries up and the aphrodisiacs kick in as your [pc.cock " + i + "] stiffens into a bulging erection, covered in gray glitter.");			
+			
+			output("\n\n");
+			if(!target.cocks[i].hasFlag(GLOBAL.FLAG_FORESKINNED) && rand(2) == 0) foreskinTF([target, i]);
+			else if(!target.cocks[i].hasFlag(GLOBAL.FLAG_SHEATHED)) sheathTF([target, i]);
+			else if(target.cocks[i].cLengthRaw < 20 && rand(2) == 0) cockLenghtTF([target, i]);
+			else if(target.cocks[i].cThicknessRatioRaw < 2) cockThickTF([target, i]);
+			else dudTF([target, i]);
+		}
+		
+		private function dudTF(arg:Array):void
+		{
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+			
+			output("Aside from a few short tingles along your [pc.cockNoun " + i + "], nothing really happens... what a waste.");
+			target.lust(100);
+			
+			kGAMECLASS.clearMenu();
+			kGAMECLASS.addButton(0,"Next",kGAMECLASS.useItemFunction);
+		}
+		
+		private function foreskinTF(arg:Array):void
+		{
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+
+			//Target penis gains a foreskin flag if lacks one. 
+			output("The gray microsurgeons begin to move, positing themselves in circular lines that run around your shaft, starting and ending at where a frenulum should be. You can barely feel these tiny machines crawling all over your [pc.skinColor] skin as it begins to bulge out, their pinching reworking it into a more desirable form. These circular lines begin to pull at the skin, stretching it with them as they climb all together towards the frenulum, leaving behind a ringed bump that will soon become your foreskin. Once that's done, the machines race back to their original spots, making more circular lines across your lenght and pull at the skin yet again. Their ascent curls that small bump of loose skin around your shaft into a thin sleeve, all of it firmly attached to a frenulum that goes all the way up to your [pc.cockHead " + i + "].");
+			output("\n\nAfter another itchy minute, they finish their work leaving you to admire the slackened foreskin that folds around your [pc.cockHead " + i + "]. The gray glitter gathers on the tip of the loose flesh and massages it into an elastic ridged band that's delightfully tight. You can see the machines slither inside and work on your cock-head, their prickles becoming increasingly more painful, or rather it looks like you are becoming much more sensitive than before.");
+			output("\n\nEventually, the prickling stops and you can't feel anything else going on with your cock, so you assume the transformation must've run its course. You begin to rub your length and explore the gliding action that your new foreskin offers. When you pull it all the way down you rediscover your [pc.cockHead " + i + "], now in a more vibrant and glistening [pc.cockColor], as the machines flake off from it. You admire how the foreskin bunches up over your tip every time you pull it all the way up and shove two fingers within, swirling them around your cockhead as pre-cum gurgles from your cum-slit. The tight band can be stretched pretty wide, sending enjoyable shivers of pleasure running across your spine as you test it with your fingers. You pull your pre-cum slicked fingers from within and the band quickly snaps back into place.");
+			output("\n\nPulling the skin all the way down you find yourself overwhelmed by the tight and sensitive band massaging your shaft. Using the skin as the cock sleeve it is, you polish your spear, slowly building yourself into an intense orgasm. You fall to your knees from pleasure and use one hand for support while the other feverishly beats your [pc.cock " + i + "]. Soon you feel your seed rising through your cumvein, so you pull the foreskin over your [pc.cockHead " + i + "] and pinch it closed. It quickly fills with your [pc.cum], ballooning it as you bask in your afterglow. You let it go and the skin rolls back, dripping its [pc.cumFlavor] contents on the floor. <b>Your [pc.cock " + i + "] now has a foreskin!</b>");
+		
+			target.cocks[i].addFlag(GLOBAL.FLAG_FORESKINNED);
+			target.orgasm();
+
+			kGAMECLASS.clearMenu();
+			kGAMECLASS.addButton(0,"Next",kGAMECLASS.useItemFunction);
+		}
+		
+		private function sheathTF(arg:Array):void
+		{
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+
+			//Target penis gains a sheath flag if lacks one. 
+			output("You can see the gray microsurgeons crawling all over your shaft and into the base of your [pc.cock " + i + "], so tightly packed against each other they look like a single silver line of body paint. At first you don't see anything happening down there, but eventually, the flesh underneath the machines begins to bloat, stretching your [pc.skinColor] skin and growing into what looks like a silver cock ring. The bulging flesh visibly throbs as the little machines do their job, pinching and pulling at the skin, stretching it longer and then curling it for extra protection. After a while they concentrate on the slit, shaping it into a tight form, to make sure it's kept closed unless you grow aroused.");
+			output("\n\nSlowly, the little gray machines begin to pour out of your [pc.skinColor] sheath, as your cock quickly recedes into its new reservoir. As your prick completely retreats within the sheath, it washes away the rest of the glitter with your pre-cum. When it seems like the transformation has run its course, you stick a finger in there, swirling it around and exploring your unfamiliar depths. ");
+			{
+				if (target.skinType == GLOBAL.SKIN_TYPE_FUR) output("You realize it's not done yet when painful trickles surge on the outside, quickly sprouting into tiny hairs. It doesn't take long for those hairs to grow into a mat of [pc.skinFurScalesColor] that completely covers your sheath.");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_FEATHERS) output("You realize it's not done yet when painful trickles surge on the outside, quickly sprouting into feathers that turn your sheath into a pillow of [pc.skinFurScalesColor].");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_SCALES) output("It completely surprises you when [pc.skinFurScalesColor] scales begin to sprout on your sheath until the flesh is completely covered in smooth scales.");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_CHITIN) output("It completely surprises you when the skin begins to harden and turn [pc.skinFurScalesColor]. Soon your sheath is completely covered in a chitinous guard.");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_BARK) output("It completely surprises you when the skin begins to harden and turn [pc.skinFurScalesColor], gaining odd ridges on the surface. Soon your sheath is completely covered in hard bark.");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_GOO) output("A few more twists here and there with your hands and you finish your [pc.skinFurScalesColor] jello sheath, one that completely fails to hide your dick.");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_LATEX) output("The glistening latex sheath you're left with stretches pretty wide and quickly snaps back into place when you release it.");
+				else if (target.skinType == GLOBAL.SKIN_TYPE_PLANT) output("Your new sheath is smooth and completely devoid of hair.");
+				else output("Your new sheath is smooth and trying to hide behind your pubes.");
+			}
+			output(" <b>Your [pc.cock " + i + "] now has a [pc.skinFurScales]-covered sheath!</b>");
+			
+			target.cocks[i].addFlag(GLOBAL.FLAG_SHEATHED);
+			target.lust(30);
+			
+			kGAMECLASS.clearMenu();
+			kGAMECLASS.addButton(0,"Next",kGAMECLASS.useItemFunction);
+		}
+		
+		private function cockLenghtTF(arg:Array):void
+		{
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+
+			//Target penis gains 0.1 of length.
+			output("You can see the gray microsurgeons forming circular lines around your cock, only to stop and fall off. For some reason they are unable to complete their program and do any of the more advanced transformations. Still, you feel <i>something</i> happening on your dick, like a strangely pleasurable itch, that soon wanes. It doesn't take long to realize <b>that your [pc.cock " + i + "] has grown a little bit longer.</b>");
+			
+			target.cocks[i].cLengthRaw += 0.1;
+			target.lust(15);
+			
+			kGAMECLASS.clearMenu();
+			kGAMECLASS.addButton(0,"Next",kGAMECLASS.useItemFunction);
+		}
+		
+		private function cockThickTF(arg:Array):void
+		{
+			var target:Creature = arg[0];
+			var i:int = arg[1];
+
+			//Target penis gains 0.1 of thickness ratio.
+			output("As soon as the gray machines start moving, they begin to fall off your prick. Seems like you won't be getting any extra skin this time. You grab your boner and play with it a bit until you notice <b>your [pc.cock " + i + "] has grown a little thicker within your grasp.</b>"); 
+			
+			target.cocks[i].cThicknessRatioRaw += 0.1;
+			target.lust(15);
+			
+			kGAMECLASS.clearMenu();
+			kGAMECLASS.addButton(0,"Next",kGAMECLASS.useItemFunction);
+		}
+	}
+}

--- a/classes/Items/Transformatives/Turtleneck.as
+++ b/classes/Items/Transformatives/Turtleneck.as
@@ -107,7 +107,7 @@ package classes.Items.Transformatives
 			var i:int = arg[1];
 			var hasUnderwear:Boolean = (target.hasLowerGarment() && !target.lowerUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_FULL) && !target.lowerUndergarment.hasFlag(GLOBAL.ITEM_FLAG_EXPOSE_GROIN));
 			
-			output("You read the instructions and open the gangster-themed jar");
+			output("You read the instructions and open the spy-themed jar");
 			if(!target.isCrotchExposed())
 			{
 				output(", followed by");

--- a/includes/appearance.as
+++ b/includes/appearance.as
@@ -2673,8 +2673,13 @@ public function dickBonusForAppearance(forTarget:Creature = null, x:int = 0):voi
 		else output2(" It’s a deep, iridescent " + target.cocks[x].cockColor + " in color. Unlike " + indefiniteArticle(target.originalRace) + " penis, the shaft is patterned with multiple bulbous bumps to stimulate potential partners, and the whole of its length is glossy and smooth.");
 	}
 	//Anemone cock flavor
-	else if(target.cocks[x].cType == GLOBAL.TYPE_ANEMONE || target.cocks[x].cType == GLOBAL.TYPE_SIREN) {
-		output2(" The crown is surrounded by tiny tentacles with a venomous, aphrodisiac payload. At its base a number of similar, longer tentacles have formed, guaranteeing that pleasure will be forced upon your partners.");
+	else if (target.cocks[x].cType == GLOBAL.TYPE_ANEMONE || target.cocks[x].cType == GLOBAL.TYPE_SIREN) 
+	{
+		if(target.cocks[x].hasFlag(GLOBAL.FLAG_FORESKINNED)) output2(" From the slit of your foreskin pokes out a bundle of");
+		else output2(" The crown is surrounded by");
+		output2(" tiny tentacles with a venomous, aphrodisiac payload. At its base a number of similar, longer tentacles have formed, ");
+		if(target.hasSheath(x)) output2("the sheath forcing them to coil around your shaft, ");
+		output2("guaranteeing that pleasure will be forced upon your partners.");
 	}
 	//Kangawang flavor
 	else if(target.cocks[x].cType == GLOBAL.TYPE_KANGAROO) {
@@ -2716,7 +2721,7 @@ public function dickBonusForAppearance(forTarget:Creature = null, x:int = 0):voi
 		output2(", soft and rounded enough to massage any passage into which it is inserted.");
 	}
 	//Sheaths
-	if(target.hasSheath(x) && target.cocks[x].cType != GLOBAL.TYPE_KANGAROO)
+	if(target.hasSheath(x) && !InCollection(target.cocks[x].cType, GLOBAL.TYPE_KANGAROO, GLOBAL.TYPE_ANEMONE, GLOBAL.TYPE_SIREN))
 	{
 		if(target.cockTotal() == 1 || (target.cockTotal() > 1 && !target.hasFullSheaths())) output2(" The shaft of your manhood naturally retracts into an animalistic sheath when completely flaccid.");
 	}
@@ -2754,10 +2759,12 @@ public function dickBonusForAppearance(forTarget:Creature = null, x:int = 0):voi
 		output2(" The ");
 		if(target.cocks[x].hasFlag(GLOBAL.FLAG_FLARED)) output2("flared ");
 		else if(target.cocks[x].hasFlag(GLOBAL.FLAG_BLUNT)) output2("blunt ");
-		output2("crown is ringed with a circle of rubbery protrusions that grow larger as you get more aroused. The entire thing is shiny and covered with tiny, sensitive nodules that leave no doubt about its demonic influences.");
+		output2("crown is ringed with a circle of rubbery protrusions that grow larger ");
+		if(target.cocks[x].hasFlag(GLOBAL.FLAG_FORESKINNED)) output2("and push the foreskin down ");
+		output2("as you get more aroused. The entire thing is shiny and covered with tiny, sensitive nodules that leave no doubt about its demonic influences.");
 	}
 	//Foreskins
-	if(target.cocks[x].hasFlag(GLOBAL.FLAG_FORESKINNED) && target.cocks[x].cType != GLOBAL.TYPE_BEE)
+	if(target.cocks[x].hasFlag(GLOBAL.FLAG_FORESKINNED) && !InCollection(target.cocks[x].cType, GLOBAL.TYPE_BEE, GLOBAL.TYPE_SIREN, GLOBAL.TYPE_ANEMONE, GLOBAL.TYPE_DEMONIC))
 	{
 		output2(" The head is also covered by stretchy foreskin, ensuring that it is kept protected and sensitive.");
 	}


### PR DESCRIPTION
A pull request implementing Turtleneck and Circumscriber to Gene's Shop. This has been heavily edited since the last post in the forums. It also has been thoroughly tested and is functional.

- Turtleneck: An item that gives the applied cock a foreskin flag, a sheath flag or a negligible increase in thickness or length.
- Circumscriber: An item that removes from the applied cock a foreskin flag, a sheath flag or a negligible amount of thickness or length.
- Some small edits to anemone, siren and demonic dicks so there is no conflict in the descriptions, when they have sheaths and foreskins.