### PR TITLE
Minor Fixes and Updates

### DIFF
--- a/classes/GameData/CombatContainer.as
+++ b/classes/GameData/CombatContainer.as
@@ -1319,11 +1319,12 @@ package classes.GameData
 				{
 					if(target.canFly() && target.hasWings())
 					{
-						output("With " + target.mfn("his", "her", "its") + " " + target.wingsDescript(true) + " quickly flapping, ");
+						output("With " + target.mfn("his", "her", "its") + " " + target.wingsDescript(true) + " quickly flapping, " + target.getCombatName());
 					}
-					output(target.getCombatName() + " lifts");
+					else output(StringUtil.capitalize(target.getCombatName(), false));
+					output(" lifts");
 					if(target.isPlural) output(" themselves from the floor and gets their " + target.feet() + " back under themselves.");
-					else output(" " + target.mfn("him", "her", "it") + "self from the floor and gets " + target.mfn("him", "her", "its") + " " + target.feet() + " back under " + target.mfn("him", "her", "it") + "self.");
+					else output(" " + target.mfn("him", "her", "it") + "self from the floor and gets " + target.mfn("his", "her", "its") + " " + target.feet() + " back under " + target.mfn("him", "her", "it") + "self.");
 					target.removeStatusEffect("Tripped");
 				}
 			}
@@ -1552,10 +1553,17 @@ package classes.GameData
 			
 			if (target.hasStatusEffect("Paralyzed"))
 			{
-				if (target is PlayerCharacter) clearOutput();
-				
-				if (target.statusEffectv1("Paralyzed") <= 1) output("The venom seems to be weakening, but you can’t move yet!");
-				else output("You try to move, but just can’t manage it!");
+				if (target is PlayerCharacter)
+				{
+					clearOutput();
+					if (target.statusEffectv1("Paralyzed") <= 1) output("The venom seems to be weakening, but you can’t move yet!");
+					else output("You try to move, but just can’t manage it!");
+				}
+				else
+				{
+					if (target.statusEffectv1("Paralyzed") <= 1) output(StringUtil.capitalize(target.getCombatName(), false) + " show" + (!target.isPlural ? "s" : "") + " slight signs of movement, the venom seems to be weakening!");
+					else output(StringUtil.capitalize(target.getCombatName(), false) + " " + (!target.isPlural ? "is" : "are") + " still too paralyzed to move!");
+				}
 			}
 	
 			if (target is PlayerCharacter) processCombat();

--- a/classes/GameData/CombatContainer.as
+++ b/classes/GameData/CombatContainer.as
@@ -850,11 +850,11 @@ package classes.GameData
 				output("\n\n[goo.name] dances around, flashing plenty of tits and ass for " + target.getCombatName() + ".");
 				if (lFailed || (dResult && (dResult.lustDamage <= 0 || dResult.lustResisted)))
 				{
-					output(" " + target.getCombatPronoun("heshe") + " looks on, clearly unimpressed.");
+					output(" " + StringUtil.capitalize(target.getCombatPronoun("heshe")) + " looks on, clearly unimpressed.");
 				}
 				else
 				{
-					output(" " + target.getCombatPronoun("heshe") + " stares mesmerized at [goo.name]’s dance, flushing with lust.");
+					output(" " + StringUtil.capitalize(target.getCombatPronoun("heshe")) + " stares mesmerized at [goo.name]’s dance, flushing with lust.");
 				}
 				
 				if (!lFailed)

--- a/classes/GameData/Pregnancy/Handlers/EggTrainerCarryTraining.as
+++ b/classes/GameData/Pregnancy/Handlers/EggTrainerCarryTraining.as
@@ -48,6 +48,7 @@ package classes.GameData.Pregnancy.Handlers
 			pData.pregnancyBellyRatingContribution += (1 * pEggs);
 			mother.bellyRatingMod += pData.pregnancyBellyRatingContribution;
 			if(!kGAMECLASS.pc.hasStatusEffect("Eggy Belly")) kGAMECLASS.pc.createStatusEffect("Eggy Belly", 0, 0, pEggs, 0, false, "Icon_DrugPill", "You've got a nice belly full of eggs to enjoy, courtesy of the bright pink Egg Trainer back on your ship.", false, 0);
+			else kGAMECLASS.pc.addStatusValue("Eggy Belly", 3, pEggs);
 		}
 		
 		public static function eggTrainerCarryTrainingEnd(mother:Creature, pregSlot:int, thisPtr:BasePregnancyHandler):void

--- a/classes/GameData/Pregnancy/Handlers/OviliumEggPregnancy.as
+++ b/classes/GameData/Pregnancy/Handlers/OviliumEggPregnancy.as
@@ -129,13 +129,14 @@ package classes.GameData.Pregnancy.Handlers
 			{
 				// v1 = number of successive doses (in case needed)
 				// v2 = cream pie counts (fertilized for big egg)
-				// v3 = N/A
+				// v3 = Temporary egg count (in case needed)
 				// v4 = N/A
 				mother.createStatusEffect("Ovilium", 1, 0, pEggs, 0, true, "Icon_DrugPill", "You are under the effects of Ovilium.", false, 0);
 			}
 			else
 			{
 				mother.addStatusValue("Ovilium", 1, 1);
+				mother.addStatusValue("Ovilium", 3, pEggs);
 			}
 		}
 		
@@ -160,6 +161,7 @@ package classes.GameData.Pregnancy.Handlers
 			var pData:PregnancyData = mother.pregnancyData[pregSlot] as PregnancyData;
 			
 			mother.bellyRatingMod -= pData.pregnancyBellyRatingContribution;
+			if(mother.hasStatusEffect("Ovilium")) mother.addStatusValue("Ovilium", 3, (-1 * pData.pregnancyQuantity));
 			
 			StatTracking.track("pregnancy/ovilium eggs laid", pData.pregnancyQuantity);
 			// doesn't count as offspring!

--- a/classes/ItemSlotClass.as
+++ b/classes/ItemSlotClass.as
@@ -201,7 +201,7 @@
 			}
 			
 			// I think the only place that bonusResistances are used atm is on shields. Going to check shields + armor + accessory? as a catchall
-			if (this.type == GLOBAL.ARMOR || this.type == GLOBAL.SHIELD || this.type == GLOBAL.ACCESSORY || this.type == GLOBAL.LOWER_UNDERGARMENT || this.type == GLOBAL.UPPER_UNDERGARMENT)
+			if (this.type == GLOBAL.ARMOR || this.type == GLOBAL.CLOTHING || this.type == GLOBAL.SHIELD || this.type == GLOBAL.ACCESSORY || this.type == GLOBAL.LOWER_UNDERGARMENT || this.type == GLOBAL.UPPER_UNDERGARMENT)
 			{
 				var resistString:String = resistancesDiff(this, oldItem);
 				if (resistString.length > 0)

--- a/classes/ItemSlotClass.as
+++ b/classes/ItemSlotClass.as
@@ -267,6 +267,8 @@
 				var aprilFools:Boolean = false;
 				var valueString:String = "";
 				
+				if(!short) valueString += ("Quantity: " + quantity + "\n");
+				
 				if (discount)
 				{
 					valueString += "Basic Price: " + Math.round(price) + " " + (!aprilFools ? "Credits" : "Dogecoins");
@@ -274,7 +276,10 @@
 					if(buyer.hasPerk("Supply And Demand")) price *= 0.95;
 					valueString += "\nFinal Price: " + Math.round(price) + " " + (!aprilFools ? "Credits" : "Dogecoins");
 				}
-				else valueString += "Price: " + Math.round(price) + " " + (!aprilFools ? "Credits" : "Dogecoins");
+				else
+				{
+					valueString += "Price: " + Math.round(price) + " " + (!aprilFools ? "Credits" : "Dogecoins");
+				}
 				
 				compareString = mergeString(compareString, valueString);
 			}
@@ -517,7 +522,7 @@
 			// Total damage difference
 			if (newDamage != 0 || oldDamage != 0)
 			{
-				damAppend += "<b>" + String(newDamage) + "</b> (";
+				damAppend += "<b>" + String(Math.round(newDamage * 100)/100) + "</b> (";
 				
 				if (newDamage > oldDamage)
 				{

--- a/classes/Items/Combat/CrystalShard.as
+++ b/classes/Items/Combat/CrystalShard.as
@@ -106,7 +106,7 @@
 		
 		public function npcUsed(targetCreature:Creature, usingCreature:Creature):void
 		{
-			kGAMECLASS.output(usingCreature.capitalA + usingCreature.short + " breaks open a crystal shard, soaking " + usingCreature.mfn("him","her","it") + "self in a greenish goo that rapidly hardens into crystal! You'll have a hard time hurting " + usingCreature.mfn("him","her","it") + "!");
+			kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " breaks open a crystal shard, soaking " + usingCreature.mfn("him","her","it") + "self in a greenish goo that rapidly hardens into crystal! You'll have a hard time hurting " + usingCreature.mfn("him","her","it") + "!");
 			targetCreature.createStatusEffect("Crystal Coated",2,0,0,0,false,"Icon_DefUp","Defense is raised by 4 points thanks to a coating of rock-hard crystals!",true,0);
 		}
 	}

--- a/classes/Items/Drinks/HoneyWine.as
+++ b/classes/Items/Drinks/HoneyWine.as
@@ -75,7 +75,7 @@
 			{
 				if(inCombat()) output("\n\n");
 				else clearOutput();
-				output(target.capitalA + target.short + " chugs down the wine, and looks a lot peppier afterward!");
+				output((inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " chugs down the wine, and looks a lot peppier afterward!");
 				if(healing > 0) kGAMECLASS.output(" (<b>+" + healing + " Energy</b>)");
 			}
 			target.imbibeAlcohol(35);

--- a/classes/Items/Miscellaneous/BBQToGo.as
+++ b/classes/Items/Miscellaneous/BBQToGo.as
@@ -84,7 +84,7 @@
 				}
 				if(inCombat()) kGAMECLASS.output("\n\n");
 				else kGAMECLASS.clearOutput();
-				kGAMECLASS.output(target.capitalA + target.short + " opens a BBQ To-Go box and wolfs down the contents, getting a");
+				kGAMECLASS.output((inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " opens a BBQ To-Go box and wolfs down the contents, getting a");
 				if(healing > 0) kGAMECLASS.output(" quick energy boost. (<b>+" + healing + " Energy</b>)");
 				else kGAMECLASS.output(" full stomach in the process.");
 				target.energy(healing);

--- a/classes/Items/Miscellaneous/EMPGrenade.as
+++ b/classes/Items/Miscellaneous/EMPGrenade.as
@@ -106,15 +106,15 @@ package classes.Items.Miscellaneous
 			if(aTarget == null)
 			{
 				if (attacker is PlayerCharacter) output("It seems you have no target to use your EMP grenade on.");
-				else output(attacker.capitalA + attacker.uniqueName + " produces an EMP grenade--but with no target to use it on, " + attacker.mfn("he", "she", "it") + " puts it away.");
+				else output(StringUtil.capitalize(attacker.getCombatName(), false) + " produces an EMP grenade--but with no target to use it on, " + attacker.mfn("he", "she", "it") + " puts it away.");
 				
 				if(!kGAMECLASS.infiniteItems()) quantity++;
 				return;
 			}
 			
-			if (attacker is PlayerCharacter) output("You pull out an EMP grenade and huck it in the direction of " + aTarget.a + aTarget.uniqueName + ".");
-			else if (aTarget is PlayerCharacter) output(attacker.capitalA + attacker.uniqueName + " produces an EMP grenade and hucks it in your direction!");
-			else output(attacker.capitalA + attacker.uniqueName + " produces an EMP grenade and hucks it in the direction of " + aTarget.a + aTarget.uniqueName + "!");
+			if (attacker is PlayerCharacter) output("You pull out an EMP grenade and huck it in the direction of " + aTarget.getCombatName() + ".");
+			else if (aTarget is PlayerCharacter) output(StringUtil.capitalize(attacker.getCombatName(), false) + " produces an EMP grenade and hucks it in your direction!");
+			else output(StringUtil.capitalize(attacker.getCombatName(), false) + " produces an EMP grenade and hucks it in the direction of " + aTarget.getCombatName() + "!");
 			
 			for (var i:int = 0; i < hGroup.length; i++)
 			{	

--- a/classes/Items/Miscellaneous/FlashGrenade.as
+++ b/classes/Items/Miscellaneous/FlashGrenade.as
@@ -96,15 +96,15 @@ package classes.Items.Miscellaneous
 			if(aTarget == null)
 			{
 				if (attacker is PlayerCharacter) output("It seems you have no target to use your flash grenade on.");
-				else output(attacker.capitalA + attacker.uniqueName + " produces a flash grenade--but with no target to use it on, " + attacker.mfn("he", "she", "it") + " puts it away.");
+				else output(StringUtil.capitalize(attacker.getCombatName(), false) + " produces a flash grenade--but with no target to use it on, " + attacker.mfn("he", "she", "it") + " puts it away.");
 				
 				if(!kGAMECLASS.infiniteItems()) quantity++;
 				return;
 			}
 			
-			if (attacker is PlayerCharacter) output("You pull out a flash grenade and huck it in the direction of " + aTarget.a + aTarget.uniqueName + ".");
-			else if (aTarget is PlayerCharacter) output(attacker.capitalA + attacker.uniqueName + " produces a flash grenade and hucks it in your direction!");
-			else output(attacker.capitalA + attacker.uniqueName + " produces a flash grenade and hucks it in the direction of " + aTarget.a + aTarget.uniqueName + "!");
+			if (attacker is PlayerCharacter) output("You pull out a flash grenade and huck it in the direction of " + aTarget.getCombatName() + ".");
+			else if (aTarget is PlayerCharacter) output(StringUtil.capitalize(attacker.getCombatName(), false) + " produces a flash grenade and hucks it in your direction!");
+			else output(StringUtil.capitalize(attacker.getCombatName(), false) + " produces a flash grenade and hucks it in the direction of " + aTarget.getCombatName() + "!");
 			
 			for (var i:int = 0; i < hGroup.length; i++)
 			{	
@@ -117,12 +117,12 @@ package classes.Items.Miscellaneous
 					cTarget.createStatusEffect("Blinded", 3, 0, 0, 0, false, "Blind", "Accuracy is reduced, and ranged attacks are far more likely to miss.", true, 0,0xFF0000);
 					
 					if (cTarget is PlayerCharacter) output("\n<b>You're blinded by the luminous flashes.</b>");
-					else output("\n<b>" + cTarget.capitalA + cTarget.uniqueName + " is blinded by the luminous flashes.</b>");
+					else output("\n<b>" + StringUtil.capitalize(cTarget.getCombatName(), false) + " is blinded by the luminous flashes.</b>");
 				}
 				else
 				{
 					if (cTarget is PlayerCharacter) output("\nYou manage to avoid the blinding projectile.");
-					else output("\n" + cTarget.capitalA + cTarget.uniqueName + " manages to avoid the blinding projectile.");
+					else output("\n" + StringUtil.capitalize(cTarget.getCombatName(), false) + " manages to avoid the blinding projectile.");
 				}
 			}
 		}

--- a/classes/Items/Miscellaneous/GrayMicrobots.as
+++ b/classes/Items/Miscellaneous/GrayMicrobots.as
@@ -109,7 +109,7 @@
 		
 		public function npcUsed(targetCreature:Creature, usingCreature:Creature):void
 		{
-			kGAMECLASS.output(usingCreature.capitalA + usingCreature.short + " pulls a vial of silvery-looking goo and downs it!");
+			kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " pulls a vial of silvery-looking goo and downs it!");
 			//{Restores moderate HP}
 			var healing:int = 40;
 			if(targetCreature.HP() + healing > targetCreature.HPMax())

--- a/classes/Items/Miscellaneous/Kalocrunch.as
+++ b/classes/Items/Miscellaneous/Kalocrunch.as
@@ -79,7 +79,7 @@
 			{
 				if(inCombat()) kGAMECLASS.output("\n\n");
 				else kGAMECLASS.clearOutput();
-				kGAMECLASS.output(target.capitalA + target.short + " opens the Kalocrunch and downs it.");
+				kGAMECLASS.output((inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " opens the Kalocrunch and downs it.");
 				if(healing > 0) kGAMECLASS.output(", getting a quick energy boost. (<b>+" + healing + " Energy</b>)");
 				else kGAMECLASS.output(" to no effect.");
 				target.energy(healing);

--- a/classes/Items/Miscellaneous/LargeEgg.as
+++ b/classes/Items/Miscellaneous/LargeEgg.as
@@ -58,7 +58,7 @@
 			{
 				if(inCombat()) kGAMECLASS.output("\n\n");
 				else kGAMECLASS.clearOutput();
-				kGAMECLASS.output(target.capitalA + target.short + " eats a brightly-colored egg");
+				kGAMECLASS.output((inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " eats a brightly-colored egg");
 				if(healing > 0) kGAMECLASS.output(" and instantly regains some health! (<b>+" + healing + " HP</b>)");
 				else kGAMECLASS.output(" to no effect.");
 				target.HP(healing);

--- a/classes/Items/Miscellaneous/MhengaMango.as
+++ b/classes/Items/Miscellaneous/MhengaMango.as
@@ -184,7 +184,7 @@
 				// Yes, NPCs can use this in combat!
 				if (inCombat()) kGAMECLASS.output("\n\n");
 				else kGAMECLASS.clearOutput();
-				kGAMECLASS.output(target.capitalA + target.short + " pulls out a Mhen’gan mango and bites into it");
+				kGAMECLASS.output((inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " pulls out a Mhen’gan mango and bites into it");
 				if (healing > 0)
 				{
 					kGAMECLASS.output(", replinishing some of [target.hisHer] energy! (<b>+" + healing + " Energy</b>)");

--- a/classes/Items/Miscellaneous/MyrNectar.as
+++ b/classes/Items/Miscellaneous/MyrNectar.as
@@ -77,7 +77,7 @@
 			{
 				if(inCombat()) kGAMECLASS.output("\n\n");
 				else kGAMECLASS.clearOutput();
-				kGAMECLASS.output(target.capitalA + target.short + " opens a thermos of nectar and drinks it");
+				kGAMECLASS.output((inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " opens a thermos of nectar and drinks it");
 				if(healing > 0) kGAMECLASS.output(", getting a quick energy boost. (<b>+" + healing + " Energy</b>)");
 				else kGAMECLASS.output(" to no effect.");
 				target.energy(healing);

--- a/classes/Items/Miscellaneous/OSStimBoost.as
+++ b/classes/Items/Miscellaneous/OSStimBoost.as
@@ -21,7 +21,7 @@ package classes.Items.Miscellaneous
 			this.stackSize = 10;
 			this.type = GLOBAL.POTION;
 			this.combatUsable = true;
-			this.requiresTarget = false;
+			this.requiresTarget = true;
 			
 			//Used on inventory buttons
 			this.shortName = "OS StimBoost";
@@ -62,8 +62,19 @@ package classes.Items.Miscellaneous
 			
 			if (usingCreature == null) usingCreature = kGAMECLASS.pc;
 			
+			var hpChange:int = 0;
+			
 			if (usingCreature == kGAMECLASS.pc)
 			{
+				if (target.isImmobilized() || target.isDefeated())
+				{
+					if(!kGAMECLASS.infiniteItems()) quantity++;
+					kGAMECLASS.clearOutput();
+					if(usingCreature == target) kGAMECLASS.output("You can’t seem to get a hold of the stimbooster at the moment!");
+					else kGAMECLASS.output("You are about to pull out an stimbooster, but " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + " wouldn’t be able to make use of it!");
+					return false;
+				}
+				
 				if (target.HP() >= target.HPMax() && target.energy() >= target.energyMax())
 				{
 					if(!kGAMECLASS.infiniteItems()) quantity++;
@@ -71,49 +82,49 @@ package classes.Items.Miscellaneous
 					kGAMECLASS.output("Using the stimbooster without need would be pretty wasteful....");
 					return false;
 				}
+				
+				kGAMECLASS.clearOutput();
+				
+				if (usingCreature == target)
+				{
+					kGAMECLASS.output("You flip the protective cap off the end of the hypospray and settle it quickly against your arm. A quick thumb of the button and the microsurgeons surge into your bloodstream near instantaneously, a distinct feeling of <i>power</i> coursing through your veins as they spread throughout your body.");
+					
+				}
 				else
 				{
-					kGAMECLASS.clearOutput();
-					
-					if (usingCreature == target)
-					{
-						kGAMECLASS.output("You flip the protective cap off the end of the hypospray and settle it quickly against your arm. A quick thumb of the button and the microsurgeons surge into your bloodstream near instantaneously, a distinct feeling of <i>power</i> coursing through your veins as they spread throughout your body.");
-						
-						var hpChange:int = gainHP(target);
-				
-						if(hpChange > 0) kGAMECLASS.output(" <b>You have gained " + hpChange + " HP!</b>");
-						target.HP(hpChange);
-						target.energyRaw = target.energyMax();
-					}
+					if(target.isPlural) kGAMECLASS.output("You pull out a stimbooster and toss it to " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + ". They quickly pop off the cap and press the business end to their body. In mere seconds " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + " look far perkier, the microsurgeons working quickly to dull the pain and weariness from their frame.");
+					else kGAMECLASS.output("You pull out a stimbooster and toss it to " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + ". " + target.mfn("He", "She", "It") + " quickly pops off the cap and presses the business end to " + target.mfn("his", "her", "its") + " body. In mere seconds " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + " looks far perkier, the microsurgeons working quickly to dull the pain and weariness from " + target.mfn("his", "her", "its") + " frame.");
 				}
+				
+				hpChange = gainHP(target);
+				if(hpChange > 0) kGAMECLASS.output(" <b>" + (inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " " + ((usingCreature == target || target.isPlural) ? "have" : "has") + " gained " + hpChange + " HP!</b>");
+				target.HP(hpChange);
+				target.energyRaw = target.energyMax();
 			}
 			else
 			{
-				
 				if(inCombat()) kGAMECLASS.output("\n\n");
 				else kGAMECLASS.clearOutput();
 				if (usingCreature == target)
 				{
-					kGAMECLASS.output(usingCreature.short + " pulls out a HP booster and jabs it into their own arm. Woosh noises etc. In mere seconds they look far perkier, the microsurgeons working quickly to dull the pains and weariness from their frame.");
-				}
-				else if (usingCreature == kGAMECLASS.pc)
-				{
-					kGAMECLASS.output("You pull out a stimbooster and toss it to " + target.getCombatName() + ". " + target.mfn("He", "She", "It") + " quickly pops off the cap and presses the business end to their body. In mere seconds "+ target.getCombatName() +" looks far perkier, the microsurgeons working quickly to dull the pains and weariness from "+target.mfn("his", "her", "its") +" frame.");
+					if(target.isPlural) kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " pulls out a stimbooster and jabs it into their own body. In mere seconds they look far perkier, the microsurgeons working quickly to dull the pain and weariness from their frame.");
+					else kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " pulls out a stimbooster and jabs it into " + target.mfn("his", "her", "its") + " own arm. In mere seconds " + target.mfn("he", "she", "it") + " looks far perkier, the microsurgeons working quickly to dull the pain and weariness from " + target.mfn("his", "her", "its") + " frame.");
 				}
 				else
 				{
-					kGAMECLASS.output(usingCreature.short + " pulls out a HP booster and jabs it against " + target.short + "’s arm. Woosh noises etc.");
+					if(target.isPlural) kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " pulls out a stimbooster and jabs it against " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + ". In mere seconds they look far perkier, the microsurgeons working quickly to dull the pain and weariness from their frame.");
+					else kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " pulls out a stimbooster and jabs it against " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + "’s arm. In mere seconds " + target.mfn("he", "she", "it") + " looks far perkier, the microsurgeons working quickly to dull the pain and weariness from " + target.mfn("his", "her", "its") + " frame.");
 				}
 				
 				hpChange = gainHP(target);
-				if(hpChange > 0) kGAMECLASS.output(" <b>" + target.short + " gained " + hpChange + " HP!</b>");
+				if(hpChange > 0) kGAMECLASS.output(" <b>" + (inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " " + (target.isPlural ? "have" : "has") + " gained " + hpChange + " HP!</b>");
 				target.HP(hpChange);
 				target.energyRaw = target.energyMax();
 			}
 
 			return false;
 		}
-
+		
 		private function gainHP(targetCreature:Creature):int
 		{
 			var currHP:int = targetCreature.HP();

--- a/classes/Items/Miscellaneous/ShieldBooster.as
+++ b/classes/Items/Miscellaneous/ShieldBooster.as
@@ -65,7 +65,7 @@
 				{
 					if(inCombat()) kGAMECLASS.output("\n\n");
 					else kGAMECLASS.clearOutput();
-					kGAMECLASS.output(targetCreature.capitalA + targetCreature.short + " can't use a shield booster without a shield generator!");
+					kGAMECLASS.output((inCombat() ? StringUtil.capitalize(targetCreature.getCombatName(), false) : (targetCreature.capitalA + targetCreature.short)) + " can't use a shield booster without a shield generator!");
 				}
 				return false;
 			}
@@ -81,7 +81,7 @@
 				{
 					if(inCombat()) kGAMECLASS.output("\n\n");
 					else kGAMECLASS.clearOutput();
-					kGAMECLASS.output(targetCreature.capitalA + targetCreature.short + " pulls out a shield booster, but quickly puts it back.");
+					kGAMECLASS.output((inCombat() ? StringUtil.capitalize(targetCreature.getCombatName(), false) : (targetCreature.capitalA + targetCreature.short)) + " pulls out a shield booster, but quickly puts it back.");
 				}
 				return false;
 			}
@@ -97,7 +97,7 @@
 				{
 					if(inCombat()) kGAMECLASS.output("\n\n");
 					else kGAMECLASS.clearOutput();
-					kGAMECLASS.output(targetCreature.capitalA + targetCreature.short + " cannot use another shield booster--doing so will risk destroying " + targetCreature.mfn("his","her","its") + " shield generator.");
+					kGAMECLASS.output((inCombat() ? StringUtil.capitalize(targetCreature.getCombatName(), false) : (targetCreature.capitalA + targetCreature.short)) + " cannot use another shield booster--doing so will risk destroying " + targetCreature.mfn("his","her","its") + " shield generator.");
 				}
 				return false;
 			}
@@ -139,7 +139,7 @@
 		
 		public function npcUsed(targetCreature:Creature, usingCreature:Creature):void
 		{
-			kGAMECLASS.output(usingCreature.capitalA + usingCreature.short + " uses a shield booster!");
+			kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " uses a shield booster!");
 			var healing:int = 40;
 			if(targetCreature.shields() + healing > targetCreature.shieldsMax())
 			{

--- a/classes/Items/Miscellaneous/SmallEgg.as
+++ b/classes/Items/Miscellaneous/SmallEgg.as
@@ -79,7 +79,7 @@
 			{
 				if(inCombat()) kGAMECLASS.output("\n\n");
 				else kGAMECLASS.clearOutput();
-				kGAMECLASS.output(target.capitalA + target.short + " eats a brightly-colored egg");
+				kGAMECLASS.output((inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " eats a brightly-colored egg");
 				if(healing > 0) kGAMECLASS.output(" and instantly regains a little health! (<b>+" + healing + " HP</b>)");
 				else kGAMECLASS.output(" to no effect.");
 				target.HP(healing);

--- a/classes/Items/Miscellaneous/TestGrenade.as
+++ b/classes/Items/Miscellaneous/TestGrenade.as
@@ -103,7 +103,7 @@ package classes.Items.Miscellaneous
 		
 		public function playerUsed(targetCreature:Creature, usingCreature:Creature):void
 		{
-			kGAMECLASS.output("You throw the grenade at the " + targetCreature.short + "!");
+			kGAMECLASS.output("You throw the grenade at the " + targetCreature.getCombatName() + "!");
 			
 			// Ideally, should probably rebuild this function on a per-item basis to weave item-specific text
 			// into the combat, and lean on the shield/hp damage functions
@@ -114,9 +114,9 @@ package classes.Items.Miscellaneous
 		
 		public function npcUsed(targetCreature:Creature, usingCreature:Creature):void
 		{
-			kGAMECLASS.output(usingCreature + " threw a grenade at");
+			kGAMECLASS.output(StringUtil.capitalize(usingCreature.getCombatName(), false) + " threw a grenade at");
 			if (targetCreature == kGAMECLASS.pc) kGAMECLASS.output(" you!");
-			else kGAMECLASS.output(" " + targetCreature.short);
+			else kGAMECLASS.output(" " + targetCreature.getCombatName() + "!");
 			
 			//kGAMECLASS.genericDamageApply(this.damage, usingCreature, targetCreature, this.damageType);
 			applyDamage(baseDamage, usingCreature, targetCreature);

--- a/classes/Items/Miscellaneous/TestHPBooster.as
+++ b/classes/Items/Miscellaneous/TestHPBooster.as
@@ -58,52 +58,67 @@ package classes.Items.Miscellaneous
 		{
 			if (usingCreature == null) usingCreature = kGAMECLASS.pc;
 			
+			var hpChange:int = 0;
+			
 			if (usingCreature == kGAMECLASS.pc)
 			{
-				if (target.HP() >= target.HPMax())
+				if (target.isImmobilized() || target.isDefeated())
+				{
+					if(!kGAMECLASS.infiniteItems()) quantity++;
+					kGAMECLASS.clearOutput();
+					if(usingCreature == target) kGAMECLASS.output("You can’t seem to get a hold of the HP booster at the moment!");
+					else kGAMECLASS.output("You are about to pull out an HP booster, but " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + " wouldn’t be able to make use of it!");
+					return false;
+				}
+				
+				if (target.HP() >= target.HPMax() && target.energy() >= target.energyMax())
 				{
 					if(!kGAMECLASS.infiniteItems()) quantity++;
 					kGAMECLASS.clearOutput();
 					kGAMECLASS.output("Using an instant HP booster whilst at full health would be pretty wasteful....");
 					return false;
 				}
+				
+				kGAMECLASS.clearOutput();
+				
+				if (usingCreature == target)
+				{
+					kGAMECLASS.output("You jab the HP booster against your arm. Woosh noises etc.");
+					
+				}
 				else
 				{
-					kGAMECLASS.clearOutput();
-					
-					if (usingCreature == target)
-					{
-						kGAMECLASS.output("You jab the booster against your arm. Woosh noises etc.");
-						
-						var hpChange:int = gainHP(target);
-				
-						if(hpChange > 0) kGAMECLASS.output(" <b>You have gained " + hpChange + " HP!</b>");
-						target.HP(hpChange);
-					}
+					if(target.isPlural) kGAMECLASS.output("You pull out an HP booster and jab it into " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + ". Woosh noises etc.");
+					else kGAMECLASS.output("You pull out an HP booster and jab it into " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + ". Woosh noises etc.");
 				}
+				
+				hpChange = gainHP(target);
+				if(hpChange > 0) kGAMECLASS.output(" <b>" + (inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " " + ((usingCreature == target || target.isPlural) ? "have" : "has") + " gained " + hpChange + " HP!</b>");
+				target.HP(hpChange);
 			}
 			else
 			{
-				
 				if(inCombat()) kGAMECLASS.output("\n\n");
 				else kGAMECLASS.clearOutput();
 				if (usingCreature == target)
 				{
-					kGAMECLASS.output(usingCreature.short + " pulls out a hp booster and jabs it into their own arm. Woosh noises etc.");
+					if(target.isPlural) kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " pulls out an HP booster and jabs it into their own arm. Woosh noises etc.");
+					else kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " pulls out an HP booster and jabs it into " + target.mfn("his", "her", "its") + " own arm. Woosh noises etc.");
 				}
 				else
 				{
-					kGAMECLASS.output(usingCreature.short + " pulls out a hp booster and jabs it against " + target.short + "s arm. Woosh noises etc.");
+					if(target.isPlural) kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " pulls out an HP booster and jabs it against " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + ". Woosh noises etc.");
+					else kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " pulls out an HP booster and jabs it against " + (inCombat() ? target.getCombatName() : (target.a + target.short)) + "’s arm. Woosh noises etc.");
 				}
 				
 				hpChange = gainHP(target);
-				if(hpChange > 0) kGAMECLASS.output(" <b>" + target.short + " gained " + hpChange + " HP!</b>");
+				if(hpChange > 0) kGAMECLASS.output(" <b>" + (inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " " + (target.isPlural ? "have" : "has") + " gained " + hpChange + " HP!</b>");
 				target.HP(hpChange);
 			}
 
 			return false;
 		}
-
+		
 		private function gainHP(targetCreature:Creature):int
 		{
 			var currHP:int = targetCreature.HP();

--- a/classes/Items/Miscellaneous/ThermalPack.as
+++ b/classes/Items/Miscellaneous/ThermalPack.as
@@ -70,7 +70,7 @@
 			{
 				kGAMECLASS.clearOutput();
 				kGAMECLASS.output(target.capitalA + target.short + " activates the Thermal Pack.");
-				if(!target.hasStatusEffect("T.Pack")) target.createStatusEffect("T.Pack",0,0,0,0,false,"Icon_Smelly","You are protected from Uveto's harsh cold... for now!",false,1440);
+				if(!target.hasStatusEffect("T.Pack")) target.createStatusEffect("T.Pack",0,0,0,0,false,"Icon_Smelly","Currently being protected from Uveto's harsh cold... for now!",false,1440);
 			}
 			return false;
 		}

--- a/classes/Items/Miscellaneous/ZilHoney.as
+++ b/classes/Items/Miscellaneous/ZilHoney.as
@@ -76,7 +76,7 @@
 			{
 				if(inCombat()) kGAMECLASS.output("\n\n");
 				else kGAMECLASS.clearOutput();
-				kGAMECLASS.output(target.capitalA + target.short + " opens a vial of honey and drinks it");
+				kGAMECLASS.output((inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " opens a vial of honey and drinks it");
 				if(healing > 0) kGAMECLASS.output(", getting a quick energy boost. (<b>+" + healing + " Energy</b>)");
 				else kGAMECLASS.output(" to no effect.");
 				target.energy(healing);

--- a/classes/Items/Recovery/PexigaSaliva.as
+++ b/classes/Items/Recovery/PexigaSaliva.as
@@ -76,7 +76,7 @@
 			{
 				if(inCombat()) kGAMECLASS.output("\n\n");
 				else kGAMECLASS.clearOutput();
-				kGAMECLASS.output(target.capitalA + target.short + " opens a vial of pexiga saliva and drinks it");
+				kGAMECLASS.output((inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " opens a vial of pexiga saliva and drinks it");
 				if(healing > 0) kGAMECLASS.output(", getting a quick energy boost. (<b>+" + healing + " Energy</b>)");
 				else kGAMECLASS.output(" to no effect.");
 				target.energy(healing);

--- a/classes/Items/Recovery/ShieldBoosterMkII.as
+++ b/classes/Items/Recovery/ShieldBoosterMkII.as
@@ -61,7 +61,7 @@
 				{
 					if(inCombat()) kGAMECLASS.output("\n\n");
 					else kGAMECLASS.clearOutput();
-					kGAMECLASS.output(targetCreature.capitalA + targetCreature.short + " can't use a shield booster without a shield generator!");
+					kGAMECLASS.output((inCombat() ? StringUtil.capitalize(targetCreature.getCombatName(), false) : (targetCreature.capitalA + targetCreature.short)) + " can't use a shield booster without a shield generator!");
 				}
 				return false;
 			}
@@ -77,7 +77,7 @@
 				{
 					if(inCombat()) kGAMECLASS.output("\n\n");
 					else kGAMECLASS.clearOutput();
-					kGAMECLASS.output(targetCreature.capitalA + targetCreature.short + " pulls out a shield booster, but quickly puts it back.");
+					kGAMECLASS.output((inCombat() ? StringUtil.capitalize(targetCreature.getCombatName(), false) : (targetCreature.capitalA + targetCreature.short)) + " pulls out a shield booster, but quickly puts it back.");
 				}
 				return false;
 			}
@@ -93,7 +93,7 @@
 				{
 					if(inCombat()) kGAMECLASS.output("\n\n");
 					else kGAMECLASS.clearOutput();
-					kGAMECLASS.output(targetCreature.capitalA + targetCreature.short + " cannot use another shield booster--doing so will risk destroying " + targetCreature.mfn("his","her","its") + " shield generator.");
+					kGAMECLASS.output((inCombat() ? StringUtil.capitalize(targetCreature.getCombatName(), false) : (targetCreature.capitalA + targetCreature.short)) + " cannot use another shield booster--doing so will risk destroying " + targetCreature.mfn("his","her","its") + " shield generator.");
 				}
 				return false;
 			}
@@ -135,7 +135,7 @@
 		
 		public function npcUsed(targetCreature:Creature, usingCreature:Creature):void
 		{
-			kGAMECLASS.output(usingCreature.capitalA + usingCreature.short + " uses a shield booster!");
+			kGAMECLASS.output((inCombat() ? StringUtil.capitalize(usingCreature.getCombatName(), false) : (usingCreature.capitalA + usingCreature.short)) + " uses a shield booster!");
 			var healing:int = 40;
 			if(targetCreature.shields() + healing > targetCreature.shieldsMax())
 			{

--- a/classes/Items/Transformatives/Goblinola.as
+++ b/classes/Items/Transformatives/Goblinola.as
@@ -699,7 +699,7 @@ package classes.Items.Transformatives
 			{
 				if(inCombat()) output("\n\n");
 				else clearOutput();
-				output(target.capitalA + target.short + " unwraps and eats a Goblinola bar");
+				output((inCombat() ? StringUtil.capitalize(target.getCombatName(), false) : (target.capitalA + target.short)) + " unwraps and eats a Goblinola bar");
 				if (healing > 0) output(", revitalizing some of [target.hisHer] health! (<b>+" + healing + " HP</b>)");
 				else output(" but to no effect.");
 				target.HP(healing);

--- a/includes/dreams.as
+++ b/includes/dreams.as
@@ -42,6 +42,7 @@ public function angelDreamGo():void
 {
 	clearOutput();
 	showName("\nANGELS...");
+	showBust("");
 	output("You awake to the light of a bright-burning sun in your eyes. The softness of the bed you once laid upon is replaced by fluffy yet somehow solid clouds. High above is a sky so bluer than a robin’s egg and seemingly endlessly vast, stretching around below you as well as above. There’s no sign of land or even a planet to be found. Stumbling up on your [pc.footOrFeet], you look around in a panic, searching for something, anything familiar, but there is nothing to be found. Not a ship, not a holoconsole, not a single other person.");
 	output("\n\nWell, except for those angels fluttering down from out of the sun’s glare.");
 	output("\n\nWait... angels? Cupping your hand to shield yourself from the unearthly radiance, you piece together the details of their forms: tall statuesque bodies clad in heavy, gold-accented robes, eyes glowing like a cloudless morning, immaculate blonde hair, and yes... radiant halos of pure light. Wings more majestic any siren’s casually flutter behind them, casting no breeze and yet somehow holding their charges aloft. Your mouth gapes open, and you make no move to close it. This is insane.");
@@ -73,6 +74,7 @@ public function angelFutaBukkakePart2():void
 {
 	clearOutput();
 	showName("\nANGELS...?")
+	showBust("");
 	output("<i>“Corruption may also be burned out with heat,”</i> the lead angel proclaims, snapping her fingers. Her halo bursts into fire, and her cock surges, growing several inches longer in the span of a single heartbeat. Its rich, pheromonal scent doubles, and your [pc.skin] feels hot. The barest breeze is like feathers stroking your molten skin. Sweating profusely, you stare in wonder, licking your lips unthinkingly. You aren’t sure if its the corruption within you or the angel’s own unholy power that’s making you crave her cock so powerfully, but you don’t care much either way. It’s too hot to think. Too hot not to pant.");
 	output("\n\nThe archon’s cockhead swells fatter and fatter, then spurts a trickle of brilliant white fluid. It slaps into your lips, splattering across your face, painting you in a layer of glowing goo. She strokes herself, willing more of her silvery pre-spunk to spurt forth, and then, midway through a squirt, she presses her flare to your [pc.lips], forcing you to kiss the pebbly flesh of its rim. True to its name, it flares wide, stretching your mouth open as it’s fed inside, making you gurgle perversely.");
 	output("\n\nWith your attentions almost entirely focused on the holy creature’s unholy beast-cock, you’re surprised to discover that your arms are starting to get sore. Not from the position you’re in but from the way you’re furiously pumping the circle of dicks around you. They’re thrust at you so lewdly, their animalistic tips leaking more of that blessed liquid over your hands, wrists, and arms. You panic briefly, unable to decide on which ones you should focus on, darting from dick to dick to dick, never giving one more than a half-dozen affectionate strokes before journeying on to the next. There’s just too much dick!");
@@ -93,6 +95,7 @@ public function angelFutaBukkakePart3():void
 {
 	clearOutput();
 	showName("\nWAKING...");
+	showBust("");
 	output("You wake up, shuddering in the throes of bliss. What a dream!");
 	pc.orgasm();
 	if((pc.hasCock() && pc.cumQ() >= 30) || (pc.hasVagina() && pc.isSquirter())) 

--- a/includes/events/atha_lets_fapper.as
+++ b/includes/events/atha_lets_fapper.as
@@ -112,7 +112,7 @@ public function letsFapUnlockFromName():String
 //Subject: You’re in to stuff like this, right?
 public function futaLetsPlayerIntroEmail():String
 {
-	var ret:String = "Hey " + pc.short + ". I saw this show that you might get a kick out of. Basically, some girl does reviews of different dicks. She uses some machine to give herself a different cock every week and ends up soaked in her own cum more often than not.\n\nIf you’re gonna watch, you probably want to do so from the privacy of your own ship, ha ha.\n\nA site address has been included below.\n\n<b>The Smut menu has been added to your ship’s Masturbate option!</b>";
+	var ret:String = "Hey " + pc.short + ". I saw this show that you might get a kick out of. Basically, some girl does reviews of different dicks. She uses some machine to give herself a different cock every week and ends up soaked in her own cum more often than not.\n\nIf you’re gonna watch, you probably want to do so from the privacy of your own ship, ha ha.\n\nA site address has been included below.\n\n(<b>The Smut menu has been added to your ship’s Masturbate option!</b>)";
 	//{Adds new option to Ship’s <i>“Masturbate”</i> menu: <i>“Smut”</i>.}
 	return ret;
 }
@@ -211,11 +211,11 @@ public function letsFapSelectionMenu():void
 		//if letsFapTrack returns a garbage value, reset
 		else
 		{
-			flags["LETS_FAP_LATEST"] = letsFapAusar;
+			flags["LETS_FAP_LATEST"] = LETS_FAP_EPISODES.indexOf(letsFapAusar);
 			trace("Invalid lets fap unlock value.");
 		}
 	}
-	addButton(0,"Latest Episode",LETS_FAP_EPISODES[flags["LETS_FAP_LATEST"]],undefined,"Latest Episode","Watch the latest episode of Let's Fap!");
+	addButton(0,"LatestEpisode",LETS_FAP_EPISODES[flags["LETS_FAP_LATEST"]],undefined,"Latest Episode","Watch the latest episode of Let's Fap!");
 	if(flags["LETS_FAP_ARCHIVES"] != undefined)
 	{
 		addButton(1,"Terran",letsFapTerran,undefined,"Terran","Watch the very first episode of Atha's show!");
@@ -225,7 +225,6 @@ public function letsFapSelectionMenu():void
 		if(letsFapTrack() >= 1 && flags["LETS_FAP_LATEST"] != letsFapAusar) addButton(5,"Ausar",letsFapAusar,undefined,"Ausar","Watch Atha try out an ausar member.");
 		if(letsFapTrack() >= 2 && flags["LETS_FAP_LATEST"] != letsFapLaquine) addButton(6,"Laquine",letsFapLaquine,undefined,"Laquine","Watch Atha try out a laquine member.");
 		if(letsFapTrack() >= 3 && flags["LETS_FAP_LATEST"] != letsFapKuiTan) addButton(7,"Kui-Tan",letsFapKuiTan,undefined,"Kui-Tan","Watch Atha try out a kui-tan member.");
-		
 		if(letsFapTrack() >= 4 && flags["LETS_FAP_LATEST"] != letsFapUnboxing) addButton(8,"Unboxing",letsFapUnboxing,undefined,"Unboxing","Watch Atha try out unboxing a toy.");
 		if(letsFapTrack() >= 5 && flags["LETS_FAP_LATEST"] != letsFapOvir) addButton(9,"Ovir",letsFapOvir,undefined,"Ovir","Watch Atha try out an ovir member.");
 		if(letsFapTrack() >= 6 && flags["LETS_FAP_LATEST"] != letsFapRahnScene) addButton(10,"Rahn",letsFapRahnScene,undefined,"Rahn","Watch Atha try out a rahn member.");

--- a/includes/events/kashimaIncident/kashimaIncident.as
+++ b/includes/events/kashimaIncident/kashimaIncident.as
@@ -877,6 +877,8 @@ public function kiHendersonNoCureII():void
 	author("Savin");
 	showName("VICTORY:\nHENDERSON");
 	showBust("ELENORA", "USHAMEE_NUDE_PREG");
+	
+	flags["KI_ESCAPE_UNCURED"] = 1;
 
 	output("<i>“Hey, what-”</i> the Chief starts to say.");
 	
@@ -900,7 +902,6 @@ public function kiHendersonNoCureII():void
 	
 	currentLocation = "KI-E25";
 	generateLocation(currentLocation);
-	flags["KI_ESCAPE_UNCURED"] = 1;
 
 	clearMenu();
 	addButton(0, "Next", mainGameMenu);

--- a/includes/events/kashimaIncident/roomfunctions.as
+++ b/includes/events/kashimaIncident/roomfunctions.as
@@ -15,25 +15,26 @@ public function kiEnterShuttleLZ():void
 
 public function kiElevatorTerminal():void
 {
-	
-	
 	flags["NAV_DISABLED"] = 0;
+	
+	output("A bank of elevators sits on the east bulkhead, all of which have big, red EMERGENCY signs printed out on their displays instead of the floor selectors. Somebody must have triggered a lockdown...");
 	
 	addButton(0, "Elevators", kiGoElevators, undefined, "Elevators", "Take a look at the personnel elevators.");
 	addButton(2, "WhiteSlime", kiElevatorWhiteStuff, undefined, "White Slime", "What's that slime on the walls... and the deck... and everywhere?");
 	
 	if (flags["KI_ESCAPE_UNCURED"] != undefined)
 	{
-		output("A bank of elevators sits on the east bulkhead, all of which have big, red EMERGENCY signs printed out on their displays instead of the floor selectors. Somebody must have triggered a lockdown...");
-		
 		output("\n\nThe north bulkhead has been cut away to reveal a now-empty lift shaft, fit for a huge cargo elevator. Peering through the hole in the bulkhead, all you can make out is an endless black void, and the not so subtle groans of the shambling, infected crew somewhere down in the darkness.");
 		
 		flags["NAV_DISABLED"] |= NAV_NORTH_DISABLE;
 	}
-	else if (flags["KI_USED_ELEVATORS"] == undefined)
-	{	
-		output("A bank of elevators sits on the east bulkhead, all of which have big, red EMERGENCY signs printed out on their displays instead of floor selectors. Somebody must have triggered a lockdown...\n\nThe north bulkhead has been cut away to reveal a heavy-duty cargo elevator, probably meant to ferry raw materials from the cargo hold at the ship's rear to the deck for transportation. The lights around it have been completely destroyed -- looks like they were torn out by hand. More of that viscous white crap is dripping down the walls of the elevator shaft, creating a horribly musky, masculine aroma that threatens to overwhelm you the closer you are to the cargo lift.");
-		
+	else
+	{
+		output("\n\nThe north bulkhead has been cut away to reveal a heavy-duty cargo elevator, probably meant to ferry raw materials from the cargo hold at the ship's rear to the deck for transportation. The lights around it have been completely destroyed -- looks like they were torn out by hand. More of that viscous white crap is dripping down the walls of the elevator shaft, creating a horribly musky, masculine aroma that threatens to overwhelm you the closer you are to the cargo lift.");
+	}
+	
+	if (flags["KI_USED_ELEVATORS"] == undefined)
+	{
 		addButton(1, "CargoLift", kiGoCargolift, undefined, "Cargo Lift", "Let's see if the cargo lift is still working. Looks like the only way you're getting out of the hangar.");
 		flags["NAV_DISABLED"] |= NAV_NORTH_DISABLE;
 	}

--- a/includes/game.as
+++ b/includes/game.as
@@ -195,6 +195,8 @@ public function mainGameMenu(minutesMoved:Number = 0):void {
 	// Update the state of the players mails -- we don't want to do this all the time (ie in process time), and we're only going to care about it at the menu root soooooo...
 	updateMailStatus();
 	
+	variableRoomUpdateCheck();
+	
 	//Set up all appropriate flags
 	//Display the room description
 	clearOutput();
@@ -1821,6 +1823,17 @@ public function variableRoomUpdateCheck():void
 	
 	// Kiro's Airlock
 	kirosShipAirlockUpdate();
+	// Kashima
+	if(flags["KI_ESCAPE_UNCURED"] != undefined)
+	{
+		rooms["KI-E23"].removeFlag(GLOBAL.LIFTDOWN);
+		rooms["KI-E23"].addFlag(GLOBAL.HAZARD);
+	}
+	else
+	{
+		rooms["KI-E23"].addFlag(GLOBAL.LIFTDOWN);
+		rooms["KI-E23"].removeFlag(GLOBAL.HAZARD);
+	}
 }
 
 public function processTime(deltaT:uint, doOut:Boolean = true):void

--- a/includes/gameStats.as
+++ b/includes/gameStats.as
@@ -1694,6 +1694,7 @@ public function displayQuestLog(showID:String = "All"):void
 						case 4: output2(" Cow-mazon"); break;
 						case 5: output2(" Double Stud"); break;
 						case 6: output2(" Undersized"); break;
+						default: output2(" <i>Unknown</i>"); break;
 					}
 					// Timer stuff
 					var treatedMinutes:Number = 10080 - pc.getStatusMinutes("The Treatment");
@@ -2016,6 +2017,7 @@ public function displayQuestLog(showID:String = "All"):void
 						break;
 					case FAZIAN_QUEST_RESCUE: output2(" Helped Hepane, <i>Locate the warehouse in Kressia and rescue Fazian!</i>"); break;
 					case FAZIAN_QUEST_BRIBED: output2(" Betrayed Hepane, Sold Fazian to tarratch slavers for 20000 credits, Completed"); break;
+					default: output2(" <i>Unknown</i>"); break;
 				}
 				if
 				(	(flags["FAZIAN_QUEST_STATE"] != FAZIAN_QUEST_OFFERING && flags["FAZIAN_QUEST_STATE"] != FAZIAN_QUEST_REJECTED)
@@ -2316,6 +2318,44 @@ public function displayQuestLog(showID:String = "All"):void
 				}
 				else output2(" <i>Not yet accepted...</i>");
 				if(flags["NAYNA_DRONES_TURNED_IN"] != undefined) output2("\n<b>* Weather Drones Turned In:</b> " + flags["NAYNA_DRONES_TURNED_IN"]);
+				sideCount++;
+			}
+		}
+		
+		if(showID == "Canadia" || showID == "All")
+		{
+			// Kiro Picardine Quest (Requires Kiro!)
+			if(flags["KIRO_KALLY_PICARDINE_QUEST"] != undefined && flags["RESCUE KIRO FROM BLUEBALLS"] == 1)
+			{
+				output2("\n<b><u>Kally’s Picardine</u></b>");
+				output2("\n<b>* Status:</b>");
+				switch(flags["KIRO_KALLY_PICARDINE_QUEST"])
+				{
+					case 0:
+						output2(" Know about it");
+						if(roamingKiroAvailable()) output2(", <i>Maybe ask Kiro about it...?</i>");
+						break;
+					case 1:
+					case 2:
+						output2(" Know of it, Asked Kiro");
+						if(!pc.hasStatusEffect("KallyKiro")) output2(", <i>Perhaps " + (flags["KIRO_KALLY_PICARDINE_QUEST"] == 1 ? "tell Kally the truth...?" : "Kally will love to know...") + "</i>");
+						else 
+						{
+							output2(", Told Kally truth");
+							if(pc.hasStatusEffect("Wait For Kally Break")) output2(", <i>Wait for Kally’s response to Kiro...</i>");
+							else output2(", <i>Has Kally responded to Kiro yet...?</i>");
+						}
+						break;
+					case -1: output2(" Know of it, Asked Kiro, Agreed to not reveal it to Kally"); break;
+					case -2: output2(" Know of it, Asked Kiro, Told Kally truth, Kally keeps it a secret from Kiro"); break;
+					case 3:
+						output2(" Know of it, Asked Kiro, Told Kally truth");
+						if(flags["KALLY_KISSED_KIRO"] == undefined) output2(", Kally thanked Kiro");
+						else output2(", Kally thanked and kissed Kiro");
+						break;
+					default: output2(" <i>Unknown</i>"); break;
+				}
+				if(InCollection(flags["KIRO_KALLY_PICARDINE_QUEST"], [3, -1, -2])) output2(", Completed");
 				sideCount++;
 			}
 		}
@@ -3362,7 +3402,7 @@ public function displayEncounterLog(showID:String = "All"):void
 						if(flags["GIANNA_STALL_SEEN"] != undefined) output2(", Fucked in stall");
 						if(flags["GIANNA_TITFUCKS"] != undefined) output2(", Titfucked her");
 						if(flags["GIANNA_GIVEN_GIRLY_ORAL_YET"] != undefined) output2(", She ate your pussy");
-						if(flags["SIXTYNINED_GIANNA"] != undefined) output2(", 69'd with her");
+						if(flags["SIXTYNINED_GIANNA"] != undefined) output2(", 69’d with her");
 						if(flags["FUCKED_GIANNA_VAGINALLY"] != undefined) output2(", Fucked her vagina");
 						if(flags["GIANNA_CUMFLATION_DISABLED"] != undefined) output2(", Cumflation disabled");
 					}
@@ -4730,6 +4770,7 @@ public function displayEncounterLog(showID:String = "All"):void
 							case 0: output2(" Purchased, <i>Retrieve at hangar...</i>"); break;
 							case 1: output2(" Purchased, Retrieved, <i>Return to Taivra...</i>"); break;
 							case 2: output2(" Purchased, Retrieved, Installed in her throne room"); break;
+							default: output2(" <i>Unknown</i>"); break;
 						}
 					}
 					if(flags["TAIVRA_FERTILE"] != undefined)
@@ -5044,30 +5085,40 @@ public function displayEncounterLog(showID:String = "All"):void
 				
 				variousCount++;
 			}
-			// Kally
-			if(flags["MET_KALLY"] != undefined)
+			// Kui Country Bar and Lodge
+			if(flags["GLORYHOLE_MOUNTER"] > 0 || flags["GLORYHOLE_SERVER"] > 0 || flags["MET_KALLY"] != undefined)
 			{
 				output2("\n<b><u>Kui Country Bar and Lodge</u></b>");
-				output2("\n<b>* Kally:</b> Met her");
-				if(flags["KIRO_MET_KALLY"] >= 4) output2(" with Kiro");
-				if(flags["KALLYS_SECRET_INGREDIENT"] != undefined) output2(", Know of her secret ingredient");
-				if(drinkFromTapKally() > 0)
+				// Gloryholes
+				if(flags["GLORYHOLE_MOUNTER"] > 0) output2("\n<b>* Gloryholes, Times Used:</b> " + flags["GLORYHOLE_MOUNTER"]);
+				if(flags["GLORYHOLE_SERVER"] > 0) output2("\n<b>* Gloryholes, Times Worked:</b> " + flags["GLORYHOLE_SERVER"]);
+				// Kally
+				if(flags["MET_KALLY"] != undefined)
 				{
-					output2("\n<b>* Kally, Times Sucked Her Cock:</b> " + drinkFromTapKally());
-					if(flags["KALLY_BIMBO_CUMCASCADE"] != undefined)
+					output2("\n<b>* Kally:</b>");
+					if(kallyIsAway()) output2(" Away");
+					else output2(" Active");
+					if(flags["KIRO_MET_KALLY"] >= 4) output2(", Met her with Kiro");
+					if(flags["KALLYS_SECRET_INGREDIENT"] != undefined) output2(", Know of her secret ingredient");
+					if(drinkFromTapKally() > 0)
 					{
-						output2(", She gave you a cum-cascade");
-						if(flags["KALLY_BIMBO_CUMCASCADE"] == 1 && drinkFromTapKally() > 1) output2(" once");
-						if(flags["KALLY_BIMBO_CUMCASCADE"] == 2) output2(" twice");
-						if(flags["KALLY_BIMBO_CUMCASCADE"] >= 3) output2(" " + flags["KALLY_BIMBO_CUMCASCADE"] + " times");
+						output2("\n<b>* Kally, Times Sucked Her Cock:</b> " + drinkFromTapKally());
+						if(flags["KALLY_BIMBO_CUMCASCADE"] != undefined)
+						{
+							output2(", She gave you a cum-cascade");
+							if(flags["KALLY_BIMBO_CUMCASCADE"] == 1 && drinkFromTapKally() > 1) output2(" once");
+							if(flags["KALLY_BIMBO_CUMCASCADE"] == 2) output2(" twice");
+							if(flags["KALLY_BIMBO_CUMCASCADE"] >= 3) output2(" " + flags["KALLY_BIMBO_CUMCASCADE"] + " times");
+						}
+						if(flags["KIRO_INTERRUPT_KALLYBEEJ"] != undefined)
+						{
+							output2(", Kiro interrupted");
+							if(flags["KIRO_INTERRUPT_KALLYBEEJ"] == 1 && drinkFromTapKally() > 1) output2(" once");
+							if(flags["KIRO_INTERRUPT_KALLYBEEJ"] == 2) output2(" twice");
+							if(flags["KIRO_INTERRUPT_KALLYBEEJ"] >= 3) output2(" " + flags["KIRO_INTERRUPT_KALLYBEEJ"] + " times");
+						}
 					}
-					if(flags["KIRO_INTERRUPT_KALLYBEEJ"] != undefined)
-					{
-						output2(", Kiro interrupted");
-						if(flags["KIRO_INTERRUPT_KALLYBEEJ"] == 1 && drinkFromTapKally() > 1) output2(" once");
-						if(flags["KIRO_INTERRUPT_KALLYBEEJ"] == 2) output2(" twice");
-						if(flags["KIRO_INTERRUPT_KALLYBEEJ"] >= 3) output2(" " + flags["KIRO_INTERRUPT_KALLYBEEJ"] + " times");
-					}
+					if(flags["KALLY_BROED"] != undefined) output2("\n<b>* Kally, Times Licked Her Out:</b> " + flags["KALLY_BROED"]);
 				}
 				variousCount++;
 			}
@@ -5233,11 +5284,10 @@ public function displayEncounterLog(showID:String = "All"):void
 			output2("\n<b>* Riley:</b> Met her");
 			if(flags["FUCKED_FREEDOM_BEEF"] == 1)
 			{
-				output2(", ");
-				if(flags["FUCKED_FREEDOM_BEEF_TAURIC"] != undefined) output2("You mounted her");
-				else if(flags["FUCKED_FREEDOM_BEEF_SNUSNU"] != undefined) output2("She gave you Snu Snu");
-				else if(flags["FUCKED_FREEDOM_BEEF_LESBOLICKS"] != undefined) output2("She ate you out");
-				else output2("Sexed her");
+				if(flags["FUCKED_FREEDOM_BEEF_TAURIC"] != undefined) output2(", You mounted her");
+				else if(flags["FUCKED_FREEDOM_BEEF_SNUSNU"] != undefined) output2(", She gave you Snu Snu");
+				else if(flags["FUCKED_FREEDOM_BEEF_LESBOLICKS"] != undefined) output2(", She ate you out");
+				else output2(", Sexed her");
 			}
 			else if(flags["FUCKED_FREEDOM_BEEF"] > 1)
 			{

--- a/includes/masturbation.eggTrainer.as
+++ b/includes/masturbation.eggTrainer.as
@@ -582,24 +582,32 @@ public function eggTrainerCarryTrainingEnds(pregSlot:int, pregEggs:int):void
 	
 	//Yay
 	clearMenu();
-	addButton(0,"Next",finalEggTCleanup);
+	addButton(0,"Next",finalEggTCleanup, pregEggs);
 }
 
 //Cleans up status effects and boots back to mainGameMenu
-public function finalEggTCleanup():void
+public function finalEggTCleanup(pregEggs:int):void
 {
-	if (!pc.hasStatusEffect("Eggy Belly")) return;
+	if (!pc.hasStatusEffect("Eggy Belly"))
+	{
+		mainGameMenu();
+		return;
+	}
 	
+	// Egg check
+	var numEggs:int = 0;
 	for (var i:int = 0; i < pc.pregnancyData.length; i++)
 	{
 		var pData:PregnancyData = pc.pregnancyData[i];
 		if (pData.pregnancyType == "EggTrainerCarryTraining") 
 		{
-			mainGameMenu();
-			return;
+			pData.pregnancyQuantity += numEggs;
 		}
 	}
-	pc.removeStatusEffect("Eggy Belly");
+	pc.addStatusValue("Eggy Belly", 3, (-1 * pregEggs));
+	if(pc.statusEffectv3("Eggy Belly") != numEggs) pc.setStatusValue("Eggy Belly", 3, numEggs);
+	if(pc.statusEffectv3("Eggy Belly") <= 0) pc.removeStatusEffect("Eggy Belly");
+	
 	mainGameMenu();
 }
 

--- a/includes/masturbation/bubbleBuddy.as
+++ b/includes/masturbation/bubbleBuddy.as
@@ -19,7 +19,7 @@ public function playerUsedBubbleBuddyInCombat(targetCreature:Creature, usingCrea
 	
 	author("Adjatha");
 	
-	var healed:Boolean = (targetCreature.HP() < targetCreature.HPMax() || targetCreature.energy() < targetCreature.energyMax());
+	var healed:Boolean = ((targetCreature.HP() < targetCreature.HPMax()) || (targetCreature.energy() < targetCreature.energyMax()));
 	
 	//{throw it like a water balloon while in combat}
 	//[Small cum Bubble]
@@ -172,10 +172,10 @@ public function playerUsedBubbleBuddyInCombat(targetCreature:Creature, usingCrea
 				//{Uses accuracy to hit, deals moderate lust damage, and may cause knock-down}
 				applyDamage(item.baseDamage, usingCreature, targetCreature);
 			}
-			if(!targetCreature.isGoo() && !targetCreature.hasStatusEffect("Tripped") && usingCreature.aim()/2 + rand(20) + 1 > targetCreature.reflexes()/4 + targetCreature.physique()/4 + 10)
+			if(!targetCreature.isGoo() && !targetCreature.hasStatusEffect("Tripped") && (((usingCreature.aim()/2) + rand(20) + 1) > ((targetCreature.reflexes()/4) + (targetCreature.physique()/4) + 10)))
 			{
 				targetCreature.createStatusEffect("Tripped", 0, 0, 0, 0, false, "DefenseDown", "Cannot act for a turn.", true, 0,0xFF0000);
-				output("\n\n<b>There’s so much that " + targetCreature.a + targetCreature.uniqueName + " is tripped!</b>");
+				output("\n\n<b>There’s so much [pc.cumNoun] that " + targetCreature.getCombatName() + " is tripped!</b>");
 			}
 		}
 	}

--- a/includes/mhenga/penny.as
+++ b/includes/mhenga/penny.as
@@ -693,7 +693,7 @@ public function approachFriendPenny(outputT:Boolean = true):void {
 	//Mission complete
 	if(flags["BADGER_QUEST"] == -3) addDisabledButton(2,"ReportBadger","Report Dr. Badger","Why would you report Dr. Badger when you've turned her into your big-breasted, bimbo badger fucktoy?");
 }
-public function friendPennyTalkMenu(func:* = null):void
+public function friendPennyTalkMenu(func:Function = null):void
 {
 	clearMenu();
 	if(func == talkToPennyAboutYourself) addDisabledButton(0, "Yourself");

--- a/includes/mhenga/penny.as
+++ b/includes/mhenga/penny.as
@@ -279,7 +279,7 @@ public function fuckTheZilForPennyBecauseYouAreADumbStupidSlut():void {
 	this.clearMenu();
 	this.addButton(0,"Explain",explainWhyYoureAHugeSlut);
 	this.addButton(1,"FlirtItOff",flirtySlutPCsTellPennyFlirts);
-	this.addButton(4,"Nevermind",askPennyIfSheNeedsHelp);
+	this.addButton(14,"Nevermind",askPennyIfSheNeedsHelp);
 }
 
 //[Explain]
@@ -658,43 +658,53 @@ public function approachFriendPenny(outputT:Boolean = true):void {
 		clearOutput();
 		output("Penny turns back up at you, greeting, <i>“’Sup, crazy? Need a hand for anything? I still owe you, you know.”</i> Her voice carries a playful undertone, like she’d rather not be working. Perhaps you could offer her a welcome distraction.");
 	}
-	this.clearMenu();
-	this.addButton(14,"Back",mainGameMenu);
-	this.addButton(0,"Talk:Yourself",talkToPennyAboutYourself);
-	this.addButton(1,"Talk:Youth",pennysYouth);
-	this.addButton(2,"Talk:Fun",whatDoesPennyDoForFun);
-	this.addButton(3,"Talk:Species",talkToPennyAboutSpecies);
-	if((pc.hasCock() || pc.hasVagina()) && pc.lust() >= 33) this.addButton(4,"Sex",pennySexFirstTime);
-	else this.addDisabledButton(4,"Sex","You need a penis or vagina and lust at or above 33 to attempt intercourse with Penny.");
+	clearMenu();
+	addButton(14,"Back",mainGameMenu);
+	addButton(0,"Talk",friendPennyTalkMenu);
+	if((pc.hasCock() || pc.hasVagina()) && pc.lust() >= 33) addButton(1,"Sex",pennySexFirstTime);
+	else addDisabledButton(1,"Sex","You need a penis or vagina and lust at or above 33 to attempt intercourse with Penny.");
 	//Go Whine to Penny that a Mustelide was Mean to You
 	//PC must have encountered Doc Badger, haven’t turned Penny into a useless cumslut
 	//Add [Badger Help] to Penny’s talk menu
 	//Tooltip: That Doctor Badger thought she could get the best of you... time to turn the tables the right way: by bringing the hammer of the LAW down on her.
 	if(flags["DR_BADGER_TURNED_IN"] == undefined)
 	{
-		if(flags["NO_REPORTING_DOC_BADGER"] != undefined) addDisabledButton(5,"ReportBadger","Report Dr. Badger","You've decided not to turn in Doctor Badger.");
-		else if(flags["MET_DR_BADGER"] != undefined) addButton(5,"ReportBadger",whineToPennyCauseYerABitch,undefined,"Report Dr. Badger","That Doctor Badger thought she could get the best of you... Time to turn the tables the right way: by bringing the hammer of the LAW down on her.");
-		else addDisabledButton(5,"Locked","Locked","Someone would have to do something illegal to you to unlock this button...");
+		if(flags["NO_REPORTING_DOC_BADGER"] != undefined) addDisabledButton(2,"ReportBadger","Report Dr. Badger","You've decided not to turn in Doctor Badger.");
+		else if(flags["MET_DR_BADGER"] != undefined) addButton(2,"ReportBadger",whineToPennyCauseYerABitch,undefined,"Report Dr. Badger","That Doctor Badger thought she could get the best of you... Time to turn the tables the right way: by bringing the hammer of the LAW down on her.");
+		else addDisabledButton(2,"Locked","Locked","Someone would have to do something illegal to you to unlock this button...");
 		
 		if(flags["BADGER_QUEST"] == 1)
 		{
-			addButton(6,"BadgerWarn",warnPennyAboutDoctorBadgersNefariousSchemes,undefined,"Warn Her About Dr. Badger","Penny would probably have some opinions about Dr. Badger's plan. Who knows, maybe she’d be into it, or maybe she’ll have some ideas about how to turn the tables on Dr. Badger instead.");
+			addButton(3,"BadgerWarn",warnPennyAboutDoctorBadgersNefariousSchemes,undefined,"Warn Her About Dr. Badger","Penny would probably have some opinions about Dr. Badger's plan. Who knows, maybe she’d be into it, or maybe she’ll have some ideas about how to turn the tables on Dr. Badger instead.");
 			if(flags["NO_ZAP_PENNY"] == undefined) 
 			{
-				if(flags["PENNY_BADGER_WARNED"] == undefined) addButton(5,"Zap Penny",surpriseZapPennyWithBimboRay,undefined,"Zap Penny","This seems like a jerk move, but if nothing else you can be pretty sure she’ll probably enjoy the end result, as will you.");
-				else addButton(5,"Zap Penny",zapPennyAfterWarningHer,undefined,"Zap Penny","Go ahead and zap Penny with the Bimbo Raygun, now that it seems like she approves.");
+				if(flags["PENNY_BADGER_WARNED"] == undefined) addButton(2,"Zap Penny",surpriseZapPennyWithBimboRay,undefined,"Zap Penny","This seems like a jerk move, but if nothing else you can be pretty sure she’ll probably enjoy the end result, as will you.");
+				else addButton(2,"Zap Penny",zapPennyAfterWarningHer,undefined,"Zap Penny","Go ahead and zap Penny with the Bimbo Raygun, now that it seems like she approves.");
 			}
-			else addDisabledButton(5,"Zap Penny","Zap Penny","Now that you've tipped her off, it'll be impossible to catch her with her guard down.");
+			else addDisabledButton(2,"Zap Penny","Zap Penny","Now that you've tipped her off, it'll be impossible to catch her with her guard down.");
 		}
 	}
-	else addDisabledButton(5,"ReportBadger","Report Dr. Badger","You already turned in Doctor Badger.");
+	else addDisabledButton(2,"ReportBadger","Report Dr. Badger","You already turned in Doctor Badger.");
 	//Penny has the doc's raygun
 	if(flags["BADGER_QUEST"] == -1 || flags["BADGER_QUEST"] == -2)
 	{
-		addDisabledButton(5,"ReportBadger","Report Dr. Badger","Why would you report Dr. Badger when you and Penny are planning to give her a taste of her own medicine?");
+		addDisabledButton(2,"ReportBadger","Report Dr. Badger","Why would you report Dr. Badger when you and Penny are planning to give her a taste of her own medicine?");
 	}
 	//Mission complete
-	if(flags["BADGER_QUEST"] == -3) addDisabledButton(5,"ReportBadger","Report Dr. Badger","Why would you report Dr. Badger when you've turned her into your big-breasted, bimbo badger fucktoy?");
+	if(flags["BADGER_QUEST"] == -3) addDisabledButton(2,"ReportBadger","Report Dr. Badger","Why would you report Dr. Badger when you've turned her into your big-breasted, bimbo badger fucktoy?");
+}
+public function friendPennyTalkMenu(func:* = null):void
+{
+	clearMenu();
+	if(func == talkToPennyAboutYourself) addDisabledButton(0, "Yourself");
+	else addButton(0, "Yourself", talkToPennyAboutYourself);
+	if(func == pennysYouth) addDisabledButton(1, "Youth");
+	else addButton(1, "Youth", pennysYouth);
+	if(func == whatDoesPennyDoForFun) addDisabledButton(2, "Fun");
+	else addButton(2, "Fun", whatDoesPennyDoForFun);
+	if(func == talkToPennyAboutSpecies) addDisabledButton(3, "Species");
+	else addButton(3, "Species", talkToPennyAboutSpecies);
+	addButton(14, "Back", approachFriendPenny, false);
 }
 
 //[Sex]
@@ -1184,8 +1194,7 @@ public function talkToPennyAboutSpecies():void {
 	
 	//Pass 30m
 	processTime(30);
-	this.clearMenu();
-	this.addButton(0,"Next",approachFriendPenny);
+	friendPennyTalkMenu(talkToPennyAboutSpecies);
 }
 
 //[Do For Fun?]
@@ -1200,8 +1209,7 @@ public function whatDoesPennyDoForFun():void {
 	output("\n\n<i>“It couldn’t hurt,”</i> you offer.");
 	output("\n\n<i>“I know, but who would we play against? The zil? I need to wait for this planet to get more than a dozen permanent, civilized residents before I try anything like that,”</i> Penny declares. <i>“Other than that, fitness is my real hobby. Being a girl, I’ve got to keep in good shape to take down some of the more burly customers I get. I can run laps around just about everyone I’ve met. The extra animal vitality I’m packing might be helping a little bit with that.”</i> She winks. <i>“That isn’t all, but if you want the whole scoop, you’ll just have to keep coming around and getting me talking until I’m comfortable telling you about my... racier hobbies.”</i>");
 	processTime(25);
-	this.clearMenu();
-	this.addButton(0,"Next",approachFriendPenny);
+	friendPennyTalkMenu(whatDoesPennyDoForFun);
 }
 
 //Her Youth
@@ -1215,8 +1223,7 @@ public function pennysYouth():void {
 	output("\n\nYou ask her if she ran off to join up after that.");
 	output("\n\n<i>“Don’t be crazy, Crazy. I finished school first before I enrolled. I wanted to protect people, even though I’m not the biggest or the strongest, and the U.G.C. gave me a chance to do that.”</i> Penny beams. <i>“The academy wasn’t easy, particularly not for a small Penny Inoue. I toughed it out all the same. You don’t get to serve law and order if you can’t take a few hits.”</i>");
 	processTime(20);
-	this.clearMenu();
-	this.addButton(0,"Next",approachFriendPenny);
+	friendPennyTalkMenu(pennysYouth);
 }
 
 //[PC Name]
@@ -1243,8 +1250,7 @@ public function talkToPennyAboutYourself():void {
 	
 	output("\n\nEars standing straight up, Penny bristles, <i>“No, I think I’ve said it all. Now, unless you have something else to discuss, I do have work to do, you know.”</i> You shrug, letting the conversation end, but before you can go anywhere, Penny looks back up at you again. <i>“Come back soon, okay crazy?”</i>");
 	processTime(20);
-	this.clearMenu();
-	this.addButton(0,"Next",approachFriendPenny);
+	friendPennyTalkMenu(talkToPennyAboutYourself);
 }
 	
 //Girlfriend Greetings

--- a/includes/mhenga/venusPitchers.as
+++ b/includes/mhenga/venusPitchers.as
@@ -1307,7 +1307,7 @@ public function venusPitcherLayUnfertilizedEgg():void {
 	output("\n\nOnce you catch your breath");
 	if (pc.isCrotchGarbed()) output(" and re-dress");
 	output(", you're left with the curious, oblong seed in front you. Using the codex, you determine that it wasn't fertilized. It also isn't considered edible by most species, but it's likely that you could consume it anyway if you didn't mind a major risk of bodily mutation to accommodate it.");
-	pc.orgasm()
+	pc.orgasm();
 	
 	if (pData && pData.pregnancyQuantity > 1) output("\n\nThe size of your [pc.belly] indicates that you're going to be going through this at least once more. You can't stop your [pc.vaginas] from tingling hotly at the thought.");
 	
@@ -1430,22 +1430,22 @@ public function layFertilizedVenusPitcherEgg():void
 		pc.elasticity += 0.1;
 		if (pc.elasticity > 2.0) pc.elasticity = 2.0;
 
-		output("\n\nAt least you feel a little stretchier now, like the act has left you better-prepared to both take and pass large insertions without issue.")
+		output("\n\nAt least you feel a little stretchier now, like the act has left you better-prepared to both take and pass large insertions without issue.");
 	}
-
-	clearMenu();
+	
 	if (InShipInterior())
 	{
-		output("\n\nSince you're on your ship, you might as well send it off to your daycare.")
+		output("\n\nSince you're on your ship, you might as well send it off to your daycare.");
 		StatTracking.track("pregnancy/fertilized venus pitcher seeds/day care");
 		StatTracking.track("pregnancy/total day care");
 		addChildVenusPitcher();
 		
+		clearMenu();
 		addButton(0, "Next", mainGameMenu);
 	}
 	else
 	{
-		output("\n\nAre you going to find a good spot for the fledgeling pitcher to root or call in a drone to have it delivered to your daycare?")
+		output("\n\nAre you going to find a good spot for the fledgeling pitcher to root or call in a drone to have it delivered to your daycare?");
 		addButton(0, "Plant It", function():void {
 			clearOutput();
 			userInterface.author("Fenoxo");

--- a/includes/myrellion/karaAndShade.as
+++ b/includes/myrellion/karaAndShade.as
@@ -109,7 +109,7 @@ public function karaFirstTimeBarStuff():void
 	clearOutput();
 	showCandice();
 	flags["BEEN_TO_MYRELLION_BAR"] = 1;
-	output("You make your way into the big, smoky lounge labeled <i>“Tavern,”</i> pushing through bat-wing doors into a crowded room full in equal measures of myr and off-worlders. What might have once been a military barracks has been cleared out by the pioneers who’ve taken over this airfield, turning it into a surprisingly cozy tavern. A long wooden bar and stools have been set up along one wall, and several makeshift tables are scattered throughout the wide room.");
+	output("You make your way into the big, smoky lounge labeled “Tavern,” pushing through bat-wing doors into a crowded room full in equal measures of myr and off-worlders. What might have once been a military barracks has been cleared out by the pioneers who’ve taken over this airfield, turning it into a surprisingly cozy tavern. A long wooden bar and stools have been set up along one wall, and several makeshift tables are scattered throughout the wide room.");
 	output("\n\nYou saunter over to the bar and take a seat, heaving a sigh as you take a load off. Going through interstellar customs is trying at the best of times; customs on a planet on the brink of self-destruction is near maddening. You rub your temples and signal to the bartender, a perky half-ausar girl in a short-cropped halter top that shows off a delightful amount of taut belly.");
 	output("\n\n<i>“Hey, " + pc.mf("handsome","cutie") + ",”</i> she says with a wink, flicking a rag over her shoulder. <i>“What can I get you?”</i>\n\nYou look over the menu and order something light to start.");
 	processTime(2);
@@ -218,7 +218,7 @@ public function notInterestedSavinYourOCsCreepMeOut():void
 	processTime(2);
 	clearMenu();
 	addButton(0,"Alright",helpDisKaraSlut,true,"Alright","Accede to her request. The girl's obviously in trouble.");
-	addButton(1,"Still No",stillSayNoToKaraYouGiganticFuckingAsshole,undefined,"Still No","Leave");
+	addButton(1,"Still No",stillSayNoToKaraYouGiganticFuckingAsshole,undefined,"Still No","Leave.");
 }
 
 //[Still No]
@@ -226,6 +226,8 @@ public function notInterestedSavinYourOCsCreepMeOut():void
 public function stillSayNoToKaraYouGiganticFuckingAsshole():void
 {
 	clearOutput();
+	clearBust();
+	showName("\nLEAVE");
 	output("You shake your head and step away from the cat-girl, leaving her to her fate.");
 	flags["LET_SHADE_AND_KARA_DUKE_IT_OUT"] = 1;
 	clearMenu();
@@ -268,7 +270,9 @@ public function helpDisKaraSlut(finishedDrink:Boolean = false):void
 public function backOfAndScrewOverKaraYouAsshat():void
 {
 	clearOutput();
-	showShade();
+	author("Savin");
+	showName("BACK\nOFF...");
+	showBust("SHADE");
 	output("As smoothly as you can, you change course away from the armed kaithrit and back toward the bar - well away from where Kara was sitting. Nobody said anything about guns. Kara’s on her own.");
 	processTime(1);
 	flags["LET_SHADE_AND_KARA_DUKE_IT_OUT"] = 1;

--- a/includes/myrellion/karaAndShade.as
+++ b/includes/myrellion/karaAndShade.as
@@ -316,7 +316,7 @@ public function turnDownAChanceToCaptureKara():void
 public function itsADealToBetrayKaraSloots():void
 {
 	clearOutput();
-	showBust("KARA","SHADE");
+	showBust("KARA","SHADE_COMBAT");
 	author("Savin");
 	showName("SHADE\n& KARA");
 	pc.addHard(10);
@@ -457,7 +457,7 @@ public function shadeSexMenu(intro:Boolean = false):void
 public function tripAndFallOnShade():void
 {
 	clearOutput();
-	showBust("KARA","SHADE");
+	showBust("KARA","SHADE_COMBAT");
 	showName("SHADE\n& KARA");
 	author("Savin");
 	pc.addMischievous(5);
@@ -481,7 +481,7 @@ public function karaAndPCVersusShadeFightIntroduction():void
 {
 	clearOutput();
 	author("Savin");
-	showBust("KARA","SHADE");
+	showBust("KARA","SHADE_COMBAT");
 	showName("SHADE\n& KARA");
 	output("You steel yourself and stand, ready to stand beside Kara.");
 	output("\n\n<i>“You brought friends?”</i> Shade spits, taking a step back and leveling the lightning gun at you. <i>“Big mistake, friend.”</i>");
@@ -505,6 +505,7 @@ public function karaAndPCVersusShadeFightIntroduction():void
 public function fuckThisShiiitImNotGettingInACatNDogFight():void
 {
 	clearOutput();
+	clearBust();
 	showName("FUCK\nTHIS!");
 	author("Savin");
 	output("Fuck this. You hop into the crowd of people fleeing, ducking out of the bar to the sounds you hear gunfire behind you.");
@@ -536,7 +537,7 @@ public function lastChanceForHelpingKara():void
 {
 	clearOutput();
 	author("Savin");
-	showBust("KARA","SHADE");
+	showBust("KARA","SHADE_COMBAT");
 	showName("SHADE\n& KARA");
 	output("You head out of the bar, trying to put the strange kaithrit’s request out of your mind. You make it all the way to the batwing doors, ready to head out into the street when you hear a scream behind you.");
 	output("\n\nYou cast a glance over your shoulder, just in time to brace yourself for a stream of people running for the doors, trying desperately to escape. Behind them, you can see a pair of kaithrit women standing in the middle of the bar leveling handguns at each other: Kara on one side, a woman dressed in a long duster that parts around a single reptilian tail behind her on the other.");
@@ -564,6 +565,7 @@ public function lastChanceForHelpingKara():void
 public function fuckDisBarShit():void
 {
 	clearOutput();
+	clearBust();
 	author("Savin");
 	output("You spend a few minutes in the crowd of people before myr security guards come rushing, weapons drawn, and charge into the bar. More gunfire ensues over another minute or so, until a guard steps outside and waves the people back in, saying that the issue has been resolved. Taking a peek through the doorway, you see a great number of bullet holes in the walls and the back door hanging open. Looks like Kara and Shade booked it. You doubt you’ll see them again.");
 	flags["SHADE_AND_KARA_RESOLVED_THINGS_THEMSELVES"] = 1;
@@ -577,7 +579,7 @@ public function helpShadeOutLastChance():void
 {
 	clearOutput();
 	author("Savin");
-	showBust("KARA","SHADE");
+	showBust("KARA","SHADE_COMBAT");
 	showName("SHADE\n& KARA");
 	output("Can’t argue with a little bounty work. You ");
 	if(!(pc.meleeWeapon is Rock)) output("draw your weapon");
@@ -605,7 +607,7 @@ public function helpKaraOutLastChance():void
 {
 	clearOutput();
 	author("Savin");
-	showBust("KARA","SHADE");
+	showBust("KARA","SHADE_COMBAT");
 	showName("SHADE\n& KARA");
 	output("You can’t leave a damsel in distress, can you? You ");
 	if(!pc.meleeWeapon is Rock) output("draw your weapon");
@@ -677,7 +679,7 @@ public function pcAndKaraBeatShade():void
 //PC + Shade defeat Kara
 public function pcAndShadeBeatKara():void
 {
-	showBust("KARA","SHADE");
+	showBust("KARA","SHADE_COMBAT");
 	showName("KARA\n& SHADE");
 	author("Savin");
 	output("Kara collapses under the hail of fire, slumping to the ground with a groan of pain.");
@@ -694,7 +696,7 @@ public function pcAndShadeBeatKara():void
 //PC + Kara Defeated
 public function loseWithKaraYouSlut():void
 {
-	showBust("KARA","SHADE");
+	showBust("KARA","SHADE_COMBAT");
 	showName("KARA\n& SHADE");
 	author("Savin");
 	output("You’ve had enough. You throw down your [pc.rangedWeapon] and put your hands up - better a little indignity than death. Kara isn’t much better off, and slowly lowers her own weapon.");

--- a/includes/myrellion/queenofthedeep.as
+++ b/includes/myrellion/queenofthedeep.as
@@ -323,6 +323,7 @@ public function queenOfTheDeepPCLoss():void
 public function queenOfTheDeepSurrenderCombat():void
 {
 	clearOutput();
+	queenOfTheDeepHeader();
 
 	output("<i>“Alright, alright! I surrender!”</i> you say, setting your [pc.weapon] down on the rocks nearby.");
 	
@@ -334,6 +335,7 @@ public function queenOfTheDeepSurrenderCombat():void
 public function queenOfTheDeepInitialSurrender():void
 {
 	clearOutput();
+	queenOfTheDeepHeader();
 
 	output("<i>“Alright, alright,”</i> you say, gently setting your [pc.weapon] down on the rocks nearby. <i>“Let’s go with pleasure.”</i>");
 	
@@ -590,6 +592,7 @@ public function queenOfTheDeepSurrenderIISplit(fromCombat:Boolean):void
 public function queenOfTheDeepSurrenderIII(fromCombat:Boolean):void
 {
 	clearOutput();
+	queenOfTheDeepHeader();
 
 	output("You awaken on the lakeshore, groggily opening your eyes. For a moment, you wonder if your encounter with the queen of the deep lake was a dream, a delusion born of darkness and isolation. That dream (or was it a nightmare?) ends when you feel something churning inside you, and your hand is drawn instinctively to your [pc.belly]. You’re gravid, and your [pc.skinFurScales] bulges with new life... the queen’s offspring squirm just under the surface, slight bulges in your flesh you can both see and feel as they adjust themselves inside you.");
 
@@ -1041,6 +1044,7 @@ public function queenOfTheDeepLeave():void
 public function queenLactationEvent():void
 {
 	clearOutput();
+	author("Savin");
 	
 	output("You feel a tightness in your [pc.chest], strong enough to make you stop dead in your tracks and clutch at your chest, trying to figure out the source of the uncomfortable sensation.");
 	if (pc.biggestTitSize() <= 0)
@@ -1063,6 +1067,7 @@ public function queenLactationEvent():void
 public function queenLactationIncreaseEvent():void
 {
 	clearOutput();
+	author("Savin");
 	
 	output("Lately you've been feeling your lactating tits get fuller and fuller, like they're swollen with more and more [pc.milkNoun] every hour. <b>You're definitely lactating more now</b>.");
 	
@@ -1075,6 +1080,7 @@ public function queenLactationIncreaseEvent():void
 public function queenBellyMovementEvent():void
 {
 	clearOutput();
+	author("Savin");
 	
 	output("You find your hands idly drifting down to your [pc.belly], caressing the taut bulge of pregnant flesh. As if responding to your touch, you feel the queen's spawn inside you moving, squirming around just beneath the surface. One seems to find its way directly to your hand, brushing against your palm through the thin barrier of your [pc.skinFurScales].");
 
@@ -1087,6 +1093,7 @@ public function queenBellyMovementEvent():void
 public function queenBellyrubEvent():void
 {
 	clearOutput();
+	author("Savin");
 	
 	output("As you're walking along, you find that a few people stop you on the street to ask you about your pregnancy: how far along are you, when are they due, can they feel your belly? You can't find the heart to tell them that your belly was filled with the spawn of a deep-dwelling monster, and squirm out of their questions as best you can.");
 
@@ -1099,6 +1106,7 @@ public function queenBellyrubEvent():void
 public function queenMorningSickness():void
 {
 	clearOutput();
+	author("Savin");
 	
 	output("A wave of nausea hits you out of nowhere, all but toppling you over. You stumble");
 	if (InShipInterior(pc)) output(" over to your vessel's restroom");
@@ -1117,6 +1125,9 @@ public function queenMorningSickness():void
 public function queenDreamEvent():void
 {
 	clearOutput();
+	author("Savin");
+	showName("WATER\nQUEEN...");
+	showBust("");
 	
 	output("<b>Your sleep is disturbed by strange dreams...</b>");
 
@@ -1139,6 +1150,7 @@ public function queenDreamEvent():void
 public function queenAlmostDueMessage():void
 {
 	clearOutput();
+	author("Savin");
 	
 	output("You note that your swollen belly is shifting awkwardly. The many water-spawn inside you are shifting more and more lately, and your body has been feeling even more wet and hot the last little while. You doubt you'll be carrying these creatures around with you much longer.");
 	
@@ -1149,6 +1161,7 @@ public function queenAlmostDueMessage():void
 public function queenPregnancyEnds():void
 {
 	clearOutput();
+	author("Savin");
 	
 	var se:StorageClass = pc.getStatusEffect("Queen Pregnancy End");
 
@@ -1203,6 +1216,7 @@ public function queenPregnancyEnds():void
 public function queenPregnancyEndsII():void
 {
 	clearOutput();
+	author("Savin");
 
 	output("You quickly lose track of time, your world fading into the abstract pleasure of birth, bringing each successive offspring to a nipple to nurse, and trying to keep others from wandering off as they adjust to their spindly legs. By the time your body seems finally empty, you count a total of " + pc.statusEffectv1("Queen Pregnancy End") + " offspring having clawed their way out of you, leaving you panting and gasping on the ground.");
 
@@ -1217,6 +1231,7 @@ public function queenPregnancyEndsII():void
 public function queenPregnancyEndsIII():void
 {
 	clearOutput();
+	author("Savin");
 
 	output("You wake up what seems like hours later, with a blanket you don’t recognize draped over you and a receipt crunched up in your hand. A note’s been written on it in messy, scratchy handwriting: <i>“Thank you for taking care of us!”</i> the first line reads. In what looks like different handwriting, a second line adds <i>“We’ll miss you! Come see us soon!”</i>");
 

--- a/includes/newTexas/tenTonGym.as
+++ b/includes/newTexas/tenTonGym.as
@@ -1006,7 +1006,7 @@ public function simoneWorkoutResults(response:String = ""):void
 				flags["SIMONE_TEASED"] = true;
 			}
 			// If PC has no penises (Vaginas only)
-			if(!pc.hasCock() || (pc.isHerm() && rand(3) == 0))
+			else if(!pc.hasCock() || (pc.isHerm() && rand(3) == 0))
 			{
 				x = rand(pc.vaginas.length);
 				

--- a/includes/tavros/nursery.as
+++ b/includes/tavros/nursery.as
@@ -457,8 +457,6 @@ public function nurseryRecordsFix():void
 		"water queen",
 		"raskvel",
 	];
-	var numInNursery:int = ChildManager.numChildrenAtNursery();
-	var numInStat:int = StatTracking.getStat("pregnancy/total day care");
 	
 	for(var i:int = 0; i < orphanList.length; i++)
 	{
@@ -468,6 +466,9 @@ public function nurseryRecordsFix():void
 			msg += "\n\n<i>" + StringUtil.toTitleCase(num2Ordinal(numFixed)) + " entry detected (" + StringUtil.toTitleCase(orphanTypes[i]) + ")... correcting... corrected.</i>";
 		}
 	}
+	
+	var numInNursery:int = ChildManager.numChildrenAtNursery();
+	var numInStat:int = StatTracking.getStat("pregnancy/total day care");
 	
 	// Nursery Stat Hotfix
 	if(numInStat < numInNursery)

--- a/includes/travelEvents.kiro.as
+++ b/includes/travelEvents.kiro.as
@@ -237,8 +237,11 @@ public function kiroTalkMenuInCanadia(arg:Function):void
 	if(arg == kiroPicardineTalk) addDisabledButton(4,"Picardine","Picardine","You just discussed this.");
 	else if(flags["KIRO_KALLY_PICARDINE_QUEST"] == undefined) addDisabledButton(4,"Locked","Locked","You don't know enough to have this discussion. Maybe there's something you need to find out from Kally...");
 	else if(flags["KIRO_KALLY_PICARDINE_QUEST"] == 1 || flags["KIRO_KALLY_PICARDINE_QUEST"] == 2) addDisabledButton(4,"Picardine","Picardine","Kiro has already made up her mind about this.");
+	else if(flags["KIRO_KALLY_PICARDINE_QUEST"] == -1) addDisabledButton(4,"Picardine","Picardine","Kiro has already made up her mind about this and you agree with her on the matter.");
+	else if(flags["KIRO_KALLY_PICARDINE_QUEST"] == -2) addDisabledButton(4,"Picardine","Picardine","Kiro has already told you and you’ve secretly told Kally. Kally intends to keep it a secret.");
 	else if(flags["KIRO_KALLY_PICARDINE_QUEST"] == 3) addDisabledButton(4,"Picardine","Picardine","Kiro has already come clean about the Picardine to her sister. There is nothing more to talk about.");	
 	else addButton(4,"Picardine",kiroPicardineTalk,undefined,"Picardine","Find out if Kiro is behind her sister's mysterious gift.");
+	
 	addButton(14,"Back",approachKiroAtTheBar,true);
 }
 
@@ -513,11 +516,11 @@ public function tellKiroToTellKallyAboutLovyPicardine():void
 	clearOutput();
 	showKiro();
 	output("<i>“Loved,”</i> you counter. <i>“She’ll know that her little sister never stopped caring about her, not for a single, solitary instant.”</i>");
-	output("\n\nKiro hunches her shoulders. When she turns her head to answer, her eyes are watery. <i>“You sure?”</i> She wipes her face against the soft fur of her forearm, blinking rapidly. <i>“It’s true, but how do I know that see it?”</i>");
+	output("\n\nKiro hunches her shoulders. When she turns her head to answer, her eyes are watery. <i>“You sure?”</i> She wipes her face against the soft fur of her forearm, blinking rapidly. <i>“It’s true, but how do I know that she’ll see it?”</i>");
 	//Bro
 	if(pc.isBro()) output("\n\nYou wrap an arm around her, grunting companionably. You’ve said more than enough.");
 	//Bimbo
-	else if(pc.isBimbo()) output("\n\nYou lean into her and kiss her on the cheek. <i>“’Cause yer a sweetie!”</i>");
+	else if(pc.isBimbo()) output("\n\nYou lean into her and kiss her on the cheek. <i>“‘Cause yer a sweetie!”</i>");
 	//Nice/Misc
 	else if(!pc.isAss()) output("\n\n<i>“How couldn’t she?”</i> you slide your arm around her waist and pull her close. <i>“For a gruff pirate, you’re practically overflowing with it.”</i>");
 	//Hard
@@ -542,6 +545,7 @@ public function tellKiroTellingKallyAboutPicardineIsShitty():void
 	output("<i>“Shitty,”</i> you agree, feeling bad for pushing the matter. Who would want to know that their whole business was built on the a pirate’s stolen goods? It would undermine Kally’s confidence in herself at best at demolish it at worst.");
 	output("\n\nKiro nods, sipping her drink. <i>“I thought so.”</i>");
 	processTime(2);
+	flags["KIRO_KALLY_PICARDINE_QUEST"] = -1;
 	clearMenu();
 	addButton(0,"Next",approachKiroAtTheBar,true);
 }
@@ -1667,7 +1671,7 @@ public function yesImTakingKirosVcards():void
 	output("\n\nHer tits jiggle from the impact while her ass bounces in your hands, but all you can truly focus on is the wet sound her cunt makes the second time it devours your [pc.cock " + x + "]. Kiro doesn’t stop there. Repeatedly moaning, she rises up, arching her back to put her bounding boobs on full display. One of her hands roughly squeezes and teases a nipple, groping the tit more for its owner’s benefit than the show she’s inadvertently providing. She’s still jacking on her cock too, pumping it with earnest strokes, squeezing larger and larger dollops of pre onto your [pc.skinFurScales].");
 	output("\n\nThe cock-stuffed tanuki is truly riding you now, her body on autopilot, clutching on your dick as she gyrates around it. Mostly, she focuses on up and down strokes that make her curvy body quiver like jello in your hands, but from time to time she’ll swivel her hips, twisting her tunnel around your [pc.cock " + x + "] like some kind of girl-cum-precipitating fuck-tornado. Her eyes are filled with pure joy, two hooded, chocolate orbs that radiate the kind of happiness that chases hot on the heels of new romantic entanglements.");
 	output("\n\n<i>“You’re gorgeous,”</i> you say, the words slipping unbidden from your lips. It’s true, though. She looks radiant there, straddling you, beading sweat that drips from her nipples as she rides you. Her pussy clenches tightly around your [pc.cock " + x + "], massaging it gleefully, trying to coax a heavy load from it.");
-	output("\n\nKiro stops bouncing long enough to wipe a tear from her eyes, but her body sees to your needs regardless, making her hips hitch back and forth enough to keep the friction going. Her cheeks are blushing pink beneath her muzzle’s fur. <i>“Y-you’re just saying that cause you’re gonna cum, aren’t you?”</i> she stammers, trying to hold in a moan.");
+	output("\n\nKiro stops bouncing long enough to wipe a tear from her eyes, but her body sees to your needs regardless, making her hips hitch back and forth enough to keep the friction going. Her cheeks are blushing pink beneath her muzzle’s fur. <i>“Y-you’re just saying that ‘cause you’re gonna cum, aren’t you?”</i> she stammers, trying to hold in a moan.");
 	output("\n\nYou leave off squeezing her ass and start groping at one of her tits, palming the heavy orb. Kiro shivers in your grip. <i>“Please, you’re way closer than me. Listen to your voice.”</i> You gently pinch her nipple, not enough to truly hurt but just enough to squeeze a high-pitched whine of pleasure from her throat.");
 	output("\n\nKiro drops down onto her elbows, trading her cow-girl in for missionary, her face just above yours. She kisses you sharply, hard enough that you feel the pressure of your teeth against the back of your [pc.lips]. Her hips lurch into motion, rocking back and forth powerfully, rubbing her clit against your [pc.belly] on the downstroke. The muscles beneath her oh-so-squeezable ass ripple beneath your clutching fingertips, an echo of the clutching tightness of Kiro’s recently-claimed cunt.");
 	output("\n\nShe couldn’t maintain the kiss if she wanted to. Breaking it, she gasps for breath, moaning like a whore and writhing atop you. Her eyes are half-vacant and distracted, unimportant next to the sensations of blissful fullness that her stuffed, slobbery twat and firm clit provide. All the girl-cum slicking you from the navel down provides a handy slip n’ slide for her quivering balls to slide over, darkening her sack with the slippery moisture. It’s the kind of wet, body-drenching fuck that you know is going to leave you both smelling richly of sex, though most of the scent will undoubtedly be from her own frenetically-leaking fluids.");

--- a/includes/uveto/roomFunctions.as
+++ b/includes/uveto/roomFunctions.as
@@ -433,7 +433,7 @@ public function removeUvetoCold(notice:Boolean = false):void
 		
 		if(notice)
 		{
-			output("\n\nThe tempurature gradually changes around you.");
+			output("\n\nThe temperature gradually changes around you.");
 			if (pc.willTakeColdDamage()) output(" With relief, you can finally take some time to defrost and enjoy the warmth!");
 		}
 	}

--- a/includes/vesperia/gloryhole.as
+++ b/includes/vesperia/gloryhole.as
@@ -397,7 +397,7 @@ public function stickDickThroughGloryhole(arg:int):void
 			//150mLs to 2L - body/face paint
 			else if(pc.cumQ() < 2000)
 			{
-				output("\n\nA good thing too, because you spray your voluminous load with enough force to gag an inexperienced cock-sucker like her.  Guiding you with both hands, she strokes you as you climax, burbling excitedly from underneath a thickening mask of [pc.cumNoun]. [pc.CumVisc] goo splashes audibly. Between it and the whimpers of your sperm-loving partner, you have more than enough auditory encouragement to squeeze out a few spurts thick enough to satisfy the lustiest cum-queen.");
+				output("\n\nA good thing too, because you spray your voluminous load with enough force to gag an inexperienced cock-sucker like her. Guiding you with both hands, she strokes you as you climax, burbling excitedly from underneath a thickening mask of [pc.cumNoun]. [pc.CumVisc] goo splashes audibly. Between it and the whimpers of your sperm-loving partner, you have more than enough auditory encouragement to squeeze out a few spurts thick enough to satisfy the lustiest cum-queen.");
 				output("\n\n<i>“S-so wet!”</i> the gloryhole occupant’s voice cheers. <i>“And you’ve still got more, don’t you?”</i> She milks you, palms sliding against iron-hard flesh, wringing you for a few last lurid dribbles. <i>“Mmmm, that’s nice.”</i> She giggles. <i>“You can’t see it, but you drenched me. My head is completely [pc.cumColor]!”</i> She kisses your [pc.cockHead " + arg + "], and you feel your own warm spoo dripping over your rod. <i>“Whoopsie!”</i>");
 				output("\n\nYou can’t help but smirk smugly at that");
 				if(!fatFlare(arg) && !fatKnot(arg)) output(" and pull your dick out, spent");

--- a/includes/vesperia/kally.as
+++ b/includes/vesperia/kally.as
@@ -54,6 +54,12 @@ public function drinkFromTapKally():Number
 	return drinks;
 }
 
+public function kallyIsAway():Boolean
+{
+	if(pc.hasStatusEffect("Kally Cummed Out")) return true;
+	return false;
+}
+
 //Kally Repeats
 public function kallyBonusRoomTexts():Boolean
 {
@@ -63,7 +69,7 @@ public function kallyBonusRoomTexts():Boolean
 		return true;
 	}
 	//Kally's isnt there!
-	if(pc.hasStatusEffect("Kally Cummed Out"))
+	if(kallyIsAway())
 	{
 		output("\n\nA small sign sits on the empty bar: ‘Break Time’");
 	}
@@ -592,9 +598,12 @@ public function kallyTalkMenu():void
 	else addDisabledButton(8,"Locked","Locked","You have not unlocked this topic. Shhh. It's a sekrit.");
 
 	if(pc.hasStatusEffect("KallyKiro")) addDisabledButton(9,"Picardine","Picardine","You already told her about the picardine. You're just waiting to see the reaction.");
-	else if((flags["KIRO_KALLY_PICARDINE_QUEST"] == 1 || flags["KIRO_KALLY_PICARDINE_QUEST"] == 2)) addButton(9,"Picardine",tellKellyPicardine,undefined,"Picardine","Tell Kally that her sister sent her that Picardine!");
-	else if(flags["KIRO_KALLY_PICARDINE_QUEST"] == 3) addDisabledButton(9,"Picardine","Picardine","You already told her about this. There's nothing more to add.");
+	else if(flags["KIRO_KALLY_PICARDINE_QUEST"] == 1 || flags["KIRO_KALLY_PICARDINE_QUEST"] == 2) addButton(9,"Picardine",tellKellyPicardine,undefined,"Picardine","Tell Kally that her sister sent her that Picardine!");
+	else if(flags["KIRO_KALLY_PICARDINE_QUEST"] == 3 || flags["KIRO_KALLY_PICARDINE_QUEST"] == -2) addDisabledButton(9,"Picardine","Picardine","You already told her about this. There's nothing more to add.");
+	else if(flags["KIRO_KALLY_PICARDINE_QUEST"] == -1) addDisabledButton(9,"Picardine","Picardine","You already discussed this with Kiro and decided not to dwell on it.");
+	else if(flags["KIRO_KALLY_PICARDINE_QUEST"] == undefined) addDisabledButton(9,"Locked","Locked","You don't know enough to discuss this topic. Perhaps you should talk to her about other things first.");
 	else addDisabledButton(9,"Locked","Locked","You don't know enough to discuss this topic, but you're pretty sure it somehow relates to her relationship with Kiro.");
+	
 	addButton(14,"Back",backToKallyMain);
 }
 
@@ -2208,7 +2217,7 @@ public function kallyBroCunnilingus3():void
 	output("\n\nFor someone so un-enhanced, she’s a damned good fuck. Do you kiss her before you go?");
 	processTime(10);
 	pc.orgasm();
-	if(!pc.hasStatusEffect("Kally Cummed Out")) pc.createStatusEffect("Kally Cummed Out",1,0,0,0,true,"Icon_Wine","",false,30,0xB793C4);
+	if(!pc.hasStatusEffect("Kally Cummed Out")) pc.createStatusEffect("Kally Cummed Out",0,0,0,0,true,"Icon_Wine","",false,30,0xB793C4);
 	IncrementFlag("KALLY_BROED");
 	clearMenu();
 	addButton(0,"Yes",yesCumKissKally);
@@ -2293,6 +2302,9 @@ public function dontTellKiroAboutPicardine():void
 	output("<i>“Don’t. Bringing it up would just make her uncomfortable.”</i> You add, <i>“I just thought you’d like to know.”</i>");
 	output("\n\nKally’s eyes fall. <i>“Oh.”</i> They brighten again. <i>“It is nice to know, even if I have to keep up the secret.”</i> A glint of mischievous wonder twinkles at the corner of her eye. <i>“I guess, in a way, we’re all sort of together on this. It’s a secret we all share, even if secretly. Thank you for telling me, [pc.name]. I know it couldn’t have been easy.”</i>");
 	processTime(1);
+	
+	flags["KIRO_KALLY_PICARDINE_QUEST"] = -2;
+	
 	clearMenu();
 	addButton(0,"Next",mainGameMenu);
 }
@@ -2330,7 +2342,7 @@ public function tellKallyToBeSerious():void
 	processTime(2);
 	//Triggers the delayed honesty variant below, similar to the kiss her scene.
 	pc.createStatusEffect("KallyKiro",0,0,0,0);
-	pc.createStatusEffect("Wait For Kally Break",1,0,0,0,true,"Icon_Wine","",false,60,0xB793C4);
+	pc.createStatusEffect("Wait For Kally Break",0,0,0,0,true,"Icon_Wine","",false,60,0xB793C4);
 	clearMenu();
 	addButton(0,"Next",mainGameMenu);
 }
@@ -2358,7 +2370,7 @@ public function yesKissKiroKally():void
 	output("You nod.");
 	output("\n\n<i>“Okay,”</i> Kally lamely agrees. <i>“You’re the expert. I’ll guess I’ll give it a try on my next break.”</i> She gives you a wan smile.");
 	pc.createStatusEffect("KallyKiro",1,0,0,0);
-	pc.createStatusEffect("Wait For Kally Break",1,0,0,0,true,"Icon_Wine","",false,60,0xB793C4);
+	pc.createStatusEffect("Wait For Kally Break",0,0,0,0,true,"Icon_Wine","",false,60,0xB793C4);
 	clearMenu();
 	addButton(0,"Next",mainGameMenu);
 }

--- a/includes/vesperia/rooms.as
+++ b/includes/vesperia/rooms.as
@@ -18,7 +18,7 @@ public function initVesperiaRoom():void
 	
 	rooms["CANADA1"] = new RoomClass(this);
 	rooms["CANADA1"].roomName = "LANDING\nPAD";
-	rooms["CANADA1"].description = "One of Canadia Station's dozens of landing pads stretches out ahead of you, seemingly exposed to the cold, endless void of space. A shimmering haze holds in an immense dome of breathable air over the area, surrounding everything from your ship to the station doors in heated safety. Spacecraft of all makes and models are lined up along one side of the polished deck, flanked by hovering support vehicles and the station's mechanics. Shadows from the larger berths, where military vessels and commercial freighters dock, occasionally flit across your view as the station spins.";
+	rooms["CANADA1"].description = "One of Canadia Station’s dozens of landing pads stretches out ahead of you, seemingly exposed to the cold, endless void of space. A shimmering haze holds in an immense dome of breathable air over the area, surrounding everything from your ship to the station doors in heated safety. Spacecraft of all makes and models are lined up along one side of the polished deck, flanked by hovering support vehicles and the station’s mechanics. Shadows from the larger berths, where military vessels and commercial freighters dock, occasionally flit across your view as the station spins.";
 	rooms["CANADA1"].planet = "CANADIA STATION";
 	rooms["CANADA1"].system = "SYSTEM: LIBERTERIA";
 	rooms["CANADA1"].southExit = "CANADA2";
@@ -30,7 +30,7 @@ public function initVesperiaRoom():void
 
 	rooms["CANADA2"] = new RoomClass(this);
 	rooms["CANADA2"].roomName = "\nAIRLOCK";
-	rooms["CANADA2"].description = "Canadia Station's airlocks are standard affairs with heavy interior and exterior doors, designed to maintain the integrity of the internal atmosphere at all costs. Presently, both are wide open, allowable only because of a hardlight-encapsulated bubble of air around the landing pad, but they'd snap closed in the space of a second in the event of a serious fault. The faded controls are completely dim and unlit, disabled until the air-bubble is powered down.";
+	rooms["CANADA2"].description = "Canadia Station’s airlocks are standard affairs with heavy interior and exterior doors, designed to maintain the integrity of the internal atmosphere at all costs. Presently, both are wide open, allowable only because of a hardlight-encapsulated bubble of air around the landing pad, but they’d snap closed in the space of a second in the event of a serious fault. The faded controls are completely dim and unlit, disabled until the air-bubble is powered down.";
 	rooms["CANADA2"].planet = "CANADIA STATION";
 	rooms["CANADA2"].system = "SYSTEM: LIBERTERIA";
 	rooms["CANADA2"].northExit = "CANADA1";
@@ -54,7 +54,7 @@ public function initVesperiaRoom():void
 
 	rooms["CANADA4"] = new RoomClass(this);
 	rooms["CANADA4"].roomName = "ACCESS\nCORRIDOR BETA";
-	rooms["CANADA4"].description = "Hanging across the access corridor is a wooden sign, laser carved to lend it a charred, rustic air. It's shaped to resemble a raccoon's tail - or a kui-tan's, the lettering striped with bands of alternating lighter and darker brown. It proudly proclaims the establishment to be the \"Kui Country Bar and Lodge.\" A thick door of reddish wood, probably a Vesperian variety replaces the station's standard portals, illuminated by a recessed indicator that glows, \"OPEN.\"";
+	rooms["CANADA4"].description = "Hanging across the access corridor is a wooden sign, laser carved to lend it a charred, rustic air. It’s shaped to resemble a raccoon’s tail - or a kui-tan’s, the lettering striped with bands of alternating lighter and darker brown. It proudly proclaims the establishment to be the “Kui Country Bar and Lodge.” A thick door of reddish wood, probably a Vesperian variety replaces the station’s standard portals, illuminated by a recessed indicator that glows, “OPEN.”";
 	rooms["CANADA4"].planet = "CANADIA STATION";
 	rooms["CANADA4"].system = "SYSTEM: LIBERTERIA";
 	rooms["CANADA4"].eastExit = "CANADA3";
@@ -81,7 +81,7 @@ public function initVesperiaRoom():void
 
 	rooms["CANADA6"] = new RoomClass(this);
 	rooms["CANADA6"].roomName = "\nRESTROOM";
-	rooms["CANADA6"].description = "The Kui Country Bar and Lodge has one enormous bathroom for all sexes, genders, and races, presumably part of a Vesperian equality initiative. The north wall has urinals positioned at a variety of heights to accommodate the various physical proportions of local males and herms. Stalls line the south side of the room, large enough for a centaur but equipped to handle the galaxy's women with equal ease. Any impression of class is ruined by graffiti labels that designate certain stalls as \"Beej Throne\" and \"Cum Palace!\" A quick peek inside reveals the presence of gloryholes - lots of them.\n\nSanitation stalls along the east wall provide plenty of opportunity to clean up after whatever biological functions you attend to within.";
+	rooms["CANADA6"].description = "The Kui Country Bar and Lodge has one enormous bathroom for all sexes, genders, and races, presumably part of a Vesperian equality initiative. The north wall has urinals positioned at a variety of heights to accommodate the various physical proportions of local males and herms. Stalls line the south side of the room, large enough for a centaur but equipped to handle the galaxy’s women with equal ease. Any impression of class is ruined by graffiti labels that designate certain stalls as “Beej Throne” and “Cum Palace!” A quick peek inside reveals the presence of gloryholes - lots of them.\n\nSanitation stalls along the east wall provide plenty of opportunity to clean up after whatever biological functions you attend to within.";
 	rooms["CANADA6"].planet = "CANADIA STATION";
 	rooms["CANADA6"].system = "SYSTEM: LIBERTERIA";
 	//rooms["CANADA6"].northExit = "";
@@ -109,8 +109,8 @@ public function initVesperiaRoom():void
 	rooms["CANADA7"].addFlag(GLOBAL.PUBLIC);
 
 	rooms["CANADA8"] = new RoomClass(this);
-	rooms["CANADA8"].roomName = "KALLY'S\nROOM";
-	rooms["CANADA8"].description = "Kally's room is... neat. Astonishingly neat. The walls are clean white affairs housing embedded lights. The diffuse lighting bathes the place in a calm, clear ambiance. She's chosen purple sheets for her bed and a lacy pink pillow, but like everything else they're spotless and meticulously arranged. A filing cabinet and desk sit beside the door, armed with a beefy holographic computer that would look more at home in a college kid's dorm room than in a serious businesswoman's abode. An enormous bottle of lube is tucked into the corner, half-hidden behind a box of \"Spunk-Monster\" brand condoms.";
+	rooms["CANADA8"].roomName = "KALLY’S\nROOM";
+	rooms["CANADA8"].description = "Kally’s room is... neat. Astonishingly neat. The walls are clean white affairs housing embedded lights. The diffuse lighting bathes the place in a calm, clear ambiance. She’s chosen purple sheets for her bed and a lacy pink pillow, but like everything else they’re spotless and meticulously arranged. A filing cabinet and desk sit beside the door, armed with a beefy holographic computer that would look more at home in a college kid’s dorm room than in a serious businesswoman’s abode. An enormous bottle of lube is tucked into the corner, half-hidden behind a box of “Spunk-Monster” brand condoms.";
 	rooms["CANADA8"].planet = "CANADIA STATION";
 	rooms["CANADA8"].system = "SYSTEM: LIBERTERIA";
 	//rooms["CANADA8"].northExit = "";
@@ -125,7 +125,7 @@ public function initVesperiaRoom():void
 
 	rooms["CANADA9"] = new RoomClass(this);
 	rooms["CANADA9"].roomName = "RENTED\nROOM";
-	rooms["CANADA9"].description = "A cushy-looking bed dominates the room, supported by a rough-hewn frame, varnished to preserve its rustic charm for all eternity. A dresser provides ample storage space as well as a home for numerous decorative knick-knacks. One that stands out is a plush beaver with a ridiculous pair of wood-carved antlers and a flat, fuzzy tail meant to serve as a coaster. You're pretty sure it's teeth would work as a bottle opener in a pinch as well. All the standard amenities one would expect are here with the added bonus of a bathroom so well equipped it would look more at home in a luxury hotel.";
+	rooms["CANADA9"].description = "A cushy-looking bed dominates the room, supported by a rough-hewn frame, varnished to preserve its rustic charm for all eternity. A dresser provides ample storage space as well as a home for numerous decorative knick-knacks. One that stands out is a plush beaver with a ridiculous pair of wood-carved antlers and a flat, fuzzy tail meant to serve as a coaster. You’re pretty sure it’s teeth would work as a bottle opener in a pinch as well. All the standard amenities one would expect are here with the added bonus of a bathroom so well equipped it would look more at home in a luxury hotel.";
 	rooms["CANADA9"].planet = "CANADIA STATION";
 	rooms["CANADA9"].system = "SYSTEM: LIBERTERIA";
 	//rooms["CANADA9"].northExit = "";


### PR DESCRIPTION
* Minor typo fixes.
* Update stats.
* Various item fixes for combat.
* Item tooltip can display "Quantity" now (mostly for if they are cropped off from the button label).
* Fix button menu for combat items that require targeting.
* **Possible for future combat items:** If item targets self and requires target, then it will enable using the item on a friendly character (if applicable) in combat. (So far, only the test HP booster and the One-Shot stim booster has this ability.)
* Clothing should now actually display resistance comparison values. (They were hidden before, causing confusion with cold resistance on Uveto).
* Possible fixes for egg laying scenes.
* Kally's Picardine mini-quest should actually end for refusing to tell Kally or Kiro.
* Potential fix for Let's Fap!'s first unlock (Ausar) to actually unlock when flag is undefined.