### PR TITLE
Some additions to inhuman structure rollback.

### DIFF
--- a/classes/Items/Transformatives/AmberSeed.as
+++ b/classes/Items/Transformatives/AmberSeed.as
@@ -344,6 +344,7 @@ package classes.Items.Transformatives
 					target.faceFlags = [GLOBAL.FLAG_MUZZLED, GLOBAL.FLAG_BEAK];
 					if (!Foxfire.colorsMatching(target)) target.lipColor = "ivory";
 					target.lipMod = -10;
+					target.femininity = 50;
 				});
 			}
 			

--- a/classes/Items/Transformatives/Catnip.as
+++ b/classes/Items/Transformatives/Catnip.as
@@ -245,9 +245,9 @@ package classes.Items.Transformatives
 			
 			// should get rid of facial hair also
 			if (target.thickness > 20 && target.thicknessUnlocked(target.thickness - 10)) changes++;
-			if (target.femininity < target.femininityMax() && target.femininityUnlocked(target.femininity + 1)) changes++;
+			if (Math.round(target.femininity) != 50 && target.femininityUnlocked(Math.round(target.femininity) + (target.femininity > 50 ? -1 : 1))) changes++;
 			
-			if (target.femininity >= target.femininityMax() && !target.hasPerk("Androgyny")) changes++;
+			if (Math.round(target.femininity) == 50 && !target.hasPerk("Androgyny")) changes++;
 			
 			var buttLimit:Number = 2;
 			if (target.hasVagina()) buttLimit = 4;
@@ -308,7 +308,7 @@ package classes.Items.Transformatives
 			
 			if (modFem(target, 100, 15, false))
 			{
-				output("\n\nYou feel a slight change in your facial structure. When they finish, <b>you feel less masculine</b>!");
+				output("\n\nYou feel a slight change in your facial structure. When they finish, <b>your gender traits are less pronounced</b>!");
 				changes++;
 			}
 			
@@ -318,11 +318,12 @@ package classes.Items.Transformatives
 				output("\n\nYou feel your [pc.lips] pucker reflexively, relaxing only to feel thinner and less pouty than before. <b>Your lips are less pronounced.</b>");
 				changes++;
 				target.lipMod--;
+				if (target.lipRating() > 2 && target.lipModUnlocked(target.lipMod - 1)) target.lipMod--;
 			}
 			
 			// hit cap and still going up! changed this one to work differently from CoC, it unties face description from femininity stat, so you can use femininity to change gender aligment without having feminine face - you can't really recognize gender from animalistic muzzle!
-			if (target.femininity >= target.femininityMax() && target.lipRating() <= 0 && !target.hasPerk("Androgyny")) {
-				output("\n\nYour [pc.face] is now very confusing - it has imponderable tint of femininity, while lacking distinct feminine features. You suspect you could make your apparent gender even more ambiguous.");
+			if (Math.round(target.femininity) == 50 && target.lipRating() <= 0 && !target.hasPerk("Androgyny")) {
+				output("\n\nYour [pc.face] is now very confusing — it would work on either a male or a female. And, according to your Codex, your microsurgeons are now attuned to keep it so.");
 				target.createPerk("Androgyny", 0, 0, 0, 0, "Your face is always androgynous.");
 				output("\n\n(<b>Perk Gained: Androgyny</b>)");
 			}

--- a/classes/Items/Transformatives/Foxfire.as
+++ b/classes/Items/Transformatives/Foxfire.as
@@ -1079,11 +1079,11 @@ package classes.Items.Transformatives
 					target.lipColor = "black";
 				}
 				
-				if (!target.hasPerk("Androgyny"))
+				if (target.femininity < 45 || target.femininity > 55)
 				{
-					AddLogEvent("Your fox's muzzle has grown so distinctly vulpine that few, if any human features remain on your face. The slender vulpine muzzle gives you a rather androgynous appearance.\n\n(<b>Perk Gained: Androgyny</b> - Your animalistic visage maintain an androgynous appearance that would befit either gender.)", "passive", target.statusEffectv4("Foxfire") - kGAMECLASS.GetGameTimestamp());
-					target.createPerk("Androgyny", 1, 0, 0, 0, "Your animalistic visage maintain an androgynous appearance that would befit either gender.");
+					ExtendLogEvent(" Your fox's muzzle has grown so distinctly vulpine that few, if any human features remain on your face. The slender vulpine muzzle gives you a rather androgynous appearance.");
 				}
+				target.femininity = 50;
 				
 				return false;
 			}
@@ -1094,6 +1094,12 @@ package classes.Items.Transformatives
 					target.addFaceFlag(GLOBAL.FLAG_MUZZLED);
 					
 					AddLogEvent("Your face begins to tingle, and is followed by a tugging sensation between your eyes. Your nose pushes outwards, widening slightly as it grows, until it rests upon your face as the signature thin <b>muzzle of a fox</b>.", "passive", target.statusEffectv4("Foxfire") - kGAMECLASS.GetGameTimestamp());
+				
+					if (target.femininity < 45 || target.femininity > 55)
+					{
+						ExtendLogEvent(" Your fox's muzzle has grown so distinctly vulpine that few, if any human features remain on your face. The slender vulpine muzzle gives you a rather androgynous appearance.");
+					}
+					target.femininity = 50;
 					
 					return false;
 				}


### PR DESCRIPTION
Foxfire no longer grants Androgyny.

Foxfire and Amber Seed now simply changing femininity score to neutral during transformation without locking it.

Catnip is pushing femininity towards neutral rather than extremely feminine before granting the Androgyny perk.